### PR TITLE
Fix: 이메일 중복 확인 Api 응답코드 변경

### DIFF
--- a/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
+++ b/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
@@ -16,8 +16,10 @@ class AuthDatasourceImpl extends AuthDatasource {
     return _dio.post(AuthApiPath.checkEmailDuplicate).then((response) {
       if (response.statusCode == 200) {
         return Success(response.data["data"] as String);
-      } else {
+      } else if (response.statusCode == 409) {
         return Failure(response.data["message"] as String);
+      } else {
+        return Failure("서버와의 연결이 원할하지 않습니다");
       }
     });
   }

--- a/test/feature/auth/data/datasources/remotes/auth_datasource_test.dart
+++ b/test/feature/auth/data/datasources/remotes/auth_datasource_test.dart
@@ -38,14 +38,33 @@ void main() {
       expect((result as Success).value, "사용 가능한 이메일입니다.");
     });
 
-    test('should return failure with message when statusCode != 200', () async {
+    test('should return failure with message when statusCode == 409', () async {
       when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
           .thenAnswer((_) async => Response(
                 requestOptions: RequestOptions(path: ""),
                 data: {
                   "status": "ERROR",
-                  "message": "이미 있는 아이디에요.",
-                  "data": null,
+                  "message": "이미 사용 중인 이메일입니다.",
+                },
+                statusCode: 409,
+              ));
+
+      final request = CheckEmailDuplicate(email: "test@test.com");
+      final result = await authDatasourceImpl.checkEmailDuplicate(request);
+
+      verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+
+      expect(result is Failure, true);
+      expect((result as Failure).message, "이미 사용 중인 이메일입니다.");
+    });
+
+    test('should return failure with message when statusCode != 200 && 409',
+        () async {
+      when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
+          .thenAnswer((_) async => Response(
+                requestOptions: RequestOptions(path: ""),
+                data: {
+                  "status": "ERROR",
                 },
                 statusCode: 400,
               ));
@@ -56,7 +75,7 @@ void main() {
       verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
 
       expect(result is Failure, true);
-      expect((result as Failure).message, "이미 있는 아이디에요.");
+      expect((result as Failure).message, "서버와의 연결이 원할하지 않습니다");
     });
   });
 }


### PR DESCRIPTION
## 작업 내용
서버 요구사항에 따라서 409 code에서는 서버 에러를 반환하고,
외 상황에 대해서는 알 수 없는 에러 메시지가 반환됩니다.

```dart
@override
  Future<Result<String>> checkEmailDuplicate(CheckEmailDuplicate request) {
    return _dio.post(AuthApiPath.checkEmailDuplicate).then((response) {
      if (response.statusCode == 200) {
        return Success(response.data["data"] as String);
      } else if (response.statusCode == 409) { // 추가됨
        return Failure(response.data["message"] as String);
      } else { // 추가됨
        return Failure("서버와의 연결이 원할하지 않습니다");
      }
    });
  }
```

이에 따라서 응답코드 409에 대한 테스트 케이스와 그 외 상황에 대한 테스트 케이스가 테스트 코드에 추가되었습니다.

## 테스트

```
$ flutter test test/feature/auth/data/datasources/remotes/auth_datasource_test.dart
```

<img width="240" height="22" alt="스크린샷 2025-08-31 오후 2 37 51" src="https://github.com/user-attachments/assets/48c85523-9d2d-448a-8408-38cda4d38382" />

