### PR TITLE
Feat: auth_datasource.dart 내부 로그인 엔드포인트 제작

### DIFF
--- a/lib/src/features/auth/data/api_path.dart
+++ b/lib/src/features/auth/data/api_path.dart
@@ -1,4 +1,5 @@
 class AuthApiPath {
   static const String path = "/api/auth";
   static const String checkEmailDuplicate = "$path/check-email-duplicate";
+  static const String login = "$path/login";
 }

--- a/lib/src/features/auth/data/datasources/remotes/auth_datasource.dart
+++ b/lib/src/features/auth/data/datasources/remotes/auth_datasource.dart
@@ -1,7 +1,10 @@
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 
 abstract class AuthDatasource {
   Future<Result<String>> checkEmailDuplicate(
       CheckEmailDuplicateRequest request);
+
+  Future<Result<Map<String, dynamic>>> login(LoginRequest request);
 }

--- a/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
+++ b/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
@@ -1,8 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/core/utils/typedefs/json_map.dart';
 import 'package:solo_play_application/src/features/auth/data/api_path.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 
 /// [AuthDatasource]의 구현체
 ///
@@ -54,6 +56,37 @@ class AuthDatasourceImpl extends AuthDatasource {
       } else {
         // 정의되지 않은 상태 코드 → 일반적인 서버 연결 실패로 간주
         return Failure("서버와의 연결이 원할하지 않습니다");
+      }
+    });
+  }
+
+  /// 로그인 요청 API 호출
+  ///
+  /// [CheckEmailDuplicate] DTO를 요청 본문으로 서버에 전달하여,
+  /// 입력된 이메일이 사용 가능한지 여부를 검사합니다.
+  ///
+  /// - 요청 경로: [AuthApiPath.login]
+  /// - 요청 방식: `POST`
+  ///
+  /// ### 반환
+  /// - [Success]<Json> : 서버가 200 OK 응답을 반환한 경우
+  ///   → `response.data["data"]` 필드에 담긴 토큰 정보를 반환
+  ///
+  /// - [Failure]<String> : 서버가 401 Unauthorized 응답을 반환한 경우
+  ///   → `response.data["message"]` 필드의 에러 메시지를 반환
+  ///
+  /// - [Failure]<String> : 기타 상태 코드이거나 예외 발생 시
+  ///   → 기본 메시지 `"서버와의 연결이 원할하지 않습니다"` 반환
+  ///
+  @override
+  Future<Result<JsonMap>> login(LoginRequest request) {
+    return _dio.post(AuthApiPath.login).then((response) {
+      if (response.statusCode == 200) {
+        return Success(response.data['data'] as JsonMap);
+      } else if (response.statusCode == 401) {
+        return Failure(response.data['message'] as String);
+      } else {
+        return Failure(response.data['message'] as String);
       }
     });
   }

--- a/lib/src/features/auth/data/models/login.dart
+++ b/lib/src/features/auth/data/models/login.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:solo_play_application/src/core/utils/typedefs/json_map.dart';
+
+part 'login.freezed.dart';
+part 'login.g.dart';
+
+@freezed
+abstract class LoginRequest with _$LoginRequest {
+  const factory LoginRequest({
+    required String email,
+    required String password,
+  }) = _LoginRequest;
+
+  factory LoginRequest.fromJson(JsonMap json) => _$LoginRequestFromJson(json);
+}

--- a/lib/src/features/auth/data/models/login.freezed.dart
+++ b/lib/src/features/auth/data/models/login.freezed.dart
@@ -1,0 +1,176 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'login.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LoginRequest {
+  String get email;
+  String get password;
+
+  /// Create a copy of LoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $LoginRequestCopyWith<LoginRequest> get copyWith =>
+      _$LoginRequestCopyWithImpl<LoginRequest>(
+          this as LoginRequest, _$identity);
+
+  /// Serializes this LoginRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is LoginRequest &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, email, password);
+
+  @override
+  String toString() {
+    return 'LoginRequest(email: $email, password: $password)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $LoginRequestCopyWith<$Res> {
+  factory $LoginRequestCopyWith(
+          LoginRequest value, $Res Function(LoginRequest) _then) =
+      _$LoginRequestCopyWithImpl;
+  @useResult
+  $Res call({String email, String password});
+}
+
+/// @nodoc
+class _$LoginRequestCopyWithImpl<$Res> implements $LoginRequestCopyWith<$Res> {
+  _$LoginRequestCopyWithImpl(this._self, this._then);
+
+  final LoginRequest _self;
+  final $Res Function(LoginRequest) _then;
+
+  /// Create a copy of LoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+  }) {
+    return _then(_self.copyWith(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _LoginRequest implements LoginRequest {
+  const _LoginRequest({required this.email, required this.password});
+  factory _LoginRequest.fromJson(Map<String, dynamic> json) =>
+      _$LoginRequestFromJson(json);
+
+  @override
+  final String email;
+  @override
+  final String password;
+
+  /// Create a copy of LoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LoginRequestCopyWith<_LoginRequest> get copyWith =>
+      __$LoginRequestCopyWithImpl<_LoginRequest>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$LoginRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LoginRequest &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, email, password);
+
+  @override
+  String toString() {
+    return 'LoginRequest(email: $email, password: $password)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$LoginRequestCopyWith<$Res>
+    implements $LoginRequestCopyWith<$Res> {
+  factory _$LoginRequestCopyWith(
+          _LoginRequest value, $Res Function(_LoginRequest) _then) =
+      __$LoginRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String email, String password});
+}
+
+/// @nodoc
+class __$LoginRequestCopyWithImpl<$Res>
+    implements _$LoginRequestCopyWith<$Res> {
+  __$LoginRequestCopyWithImpl(this._self, this._then);
+
+  final _LoginRequest _self;
+  final $Res Function(_LoginRequest) _then;
+
+  /// Create a copy of LoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+  }) {
+    return _then(_LoginRequest(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/features/auth/data/models/login.g.dart
+++ b/lib/src/features/auth/data/models/login.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_LoginRequest _$LoginRequestFromJson(Map<String, dynamic> json) =>
+    _LoginRequest(
+      email: json['email'] as String,
+      password: json['password'] as String,
+    );
+
+Map<String, dynamic> _$LoginRequestToJson(_LoginRequest instance) =>
+    <String, dynamic>{
+      'email': instance.email,
+      'password': instance.password,
+    };

--- a/test/feature/auth/data/datasources/remotes/auth_datasource_test.dart
+++ b/test/feature/auth/data/datasources/remotes/auth_datasource_test.dart
@@ -4,6 +4,7 @@ import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/api_path.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:test/test.dart';
 
 class MockDio extends Mock implements Dio {}
@@ -13,69 +14,153 @@ void main() {
     late MockDio mockDio;
     late AuthDatasourceImpl authDatasourceImpl;
 
-    setUp(() {
-      mockDio = MockDio();
-      authDatasourceImpl = AuthDatasourceImpl(dio: mockDio);
+    group('when call "/api/auth/check-email-duplicate', () {
+      setUp(() {
+        mockDio = MockDio();
+        authDatasourceImpl = AuthDatasourceImpl(dio: mockDio);
+      });
+      test('should returns success with data when statusCode == 200', () async {
+        when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
+            .thenAnswer((_) async => Response(
+                  requestOptions: RequestOptions(path: ""),
+                  data: {
+                    "status": "SUCCESS",
+                    "message": "",
+                    "data": "사용 가능한 이메일입니다.",
+                  },
+                  statusCode: 200,
+                ));
+
+        final request = CheckEmailDuplicateRequest(email: "test@test.com");
+        final result = await authDatasourceImpl.checkEmailDuplicate(request);
+        verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+
+        expect(result is Success, true);
+        expect((result as Success).value, "사용 가능한 이메일입니다.");
+      });
+
+      test('should return failure with message when statusCode == 409',
+          () async {
+        when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
+            .thenAnswer((_) async => Response(
+                  requestOptions: RequestOptions(path: ""),
+                  data: {
+                    "status": "ERROR",
+                    "message": "이미 사용 중인 이메일입니다.",
+                  },
+                  statusCode: 409,
+                ));
+
+        final request = CheckEmailDuplicateRequest(email: "test@test.com");
+        final result = await authDatasourceImpl.checkEmailDuplicate(request);
+
+        verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+
+        expect(result is Failure, true);
+        expect((result as Failure).message, "이미 사용 중인 이메일입니다.");
+      });
+
+      test('should return failure with message when statusCode != 200 && 409',
+          () async {
+        when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
+            .thenAnswer((_) async => Response(
+                  requestOptions: RequestOptions(path: ""),
+                  data: {
+                    "status": "ERROR",
+                  },
+                  statusCode: 400,
+                ));
+
+        final request = CheckEmailDuplicateRequest(email: "test@test.com");
+        final result = await authDatasourceImpl.checkEmailDuplicate(request);
+
+        verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+
+        expect(result is Failure, true);
+        expect((result as Failure).message, "서버와의 연결이 원할하지 않습니다");
+      });
     });
 
-    test('should returns success with data when statusCode == 200', () async {
-      when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
-          .thenAnswer((_) async => Response(
-                requestOptions: RequestOptions(path: ""),
-                data: {
-                  "status": "SUCCESS",
-                  "message": "",
-                  "data": "사용 가능한 이메일입니다.",
-                },
-                statusCode: 200,
-              ));
+    group('when call /api/auth/login', () {
+      setUp(() {
+        mockDio = MockDio();
+        authDatasourceImpl = AuthDatasourceImpl(dio: mockDio);
+      });
 
-      final request = CheckEmailDuplicateRequest(email: "test@test.com");
-      final result = await authDatasourceImpl.checkEmailDuplicate(request);
-      verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+      test('should returns success with data when statusCode == 200', () async {
+        when(
+          () => mockDio.post(AuthApiPath.login),
+        ).thenAnswer((_) async => Response(
+              requestOptions: RequestOptions(path: ""),
+              data: {
+                "status": "SUCCESS",
+                "message": "로그인에 성공했습니다.",
+                "data": {
+                  "grantType": "Bearer",
+                  "accessToken": "test-access-key",
+                  "refreshToken": "test-refresh-key"
+                }
+              },
+              statusCode: 200,
+            ));
 
-      expect(result is Success, true);
-      expect((result as Success).value, "사용 가능한 이메일입니다.");
-    });
+        final request =
+            LoginRequest(email: 'test@test.com', password: 'test-password');
+        final result = await authDatasourceImpl.login(request);
 
-    test('should return failure with message when statusCode == 409', () async {
-      when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
-          .thenAnswer((_) async => Response(
-                requestOptions: RequestOptions(path: ""),
-                data: {
-                  "status": "ERROR",
-                  "message": "이미 사용 중인 이메일입니다.",
-                },
-                statusCode: 409,
-              ));
+        verify(() => mockDio.post(AuthApiPath.login)).called(1);
 
-      final request = CheckEmailDuplicateRequest(email: "test@test.com");
-      final result = await authDatasourceImpl.checkEmailDuplicate(request);
+        expect(result is Success, true);
+        expect((result as Success<Map<String, dynamic>>).value['accessToken'],
+            "test-access-key");
+        expect((result).value['refreshToken'], "test-refresh-key");
+      });
 
-      verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+      test('should returns failure with message when statusCode == 401',
+          () async {
+        when(
+          () => mockDio.post(AuthApiPath.login),
+        ).thenAnswer((_) async => Response(
+              requestOptions: RequestOptions(path: ""),
+              data: {
+                "errorCode": "LOGIN_FAILED",
+                "message": "가입되지 않은 이메일이거나, 비밀번호가 올바르지 않습니다."
+              },
+              statusCode: 401,
+            ));
 
-      expect(result is Failure, true);
-      expect((result as Failure).message, "이미 사용 중인 이메일입니다.");
-    });
+        final request =
+            LoginRequest(email: 'test@test.com', password: 'test-password');
+        final result = await authDatasourceImpl.login(request);
 
-    test('should return failure with message when statusCode != 200 && 409',
-        () async {
-      when(() => mockDio.post(AuthApiPath.checkEmailDuplicate))
-          .thenAnswer((_) async => Response(
-                requestOptions: RequestOptions(path: ""),
-                data: {
-                  "status": "ERROR",
-                },
-                statusCode: 400,
-              ));
+        verify(() => mockDio.post(AuthApiPath.login)).called(1);
 
-      final request = CheckEmailDuplicateRequest(email: "test@test.com");
-      final result = await authDatasourceImpl.checkEmailDuplicate(request);
+        expect(result is Failure, true);
+        expect((result as Failure).message, "가입되지 않은 이메일이거나, 비밀번호가 올바르지 않습니다.");
+      });
 
-      verify(() => mockDio.post(AuthApiPath.checkEmailDuplicate)).called(1);
+      test('should returns failure with message when statusCode == 500',
+          () async {
+        when(
+          () => mockDio.post(AuthApiPath.login),
+        ).thenAnswer((_) async => Response(
+              requestOptions: RequestOptions(path: ""),
+              data: {
+                "errorCode": "UNEXPECTED_ERROR",
+                "message": "알 수 없는 에러가 발생했습니다."
+              },
+              statusCode: 500,
+            ));
 
-      expect(result is Failure, true);
-      expect((result as Failure).message, "서버와의 연결이 원할하지 않습니다");
+        final request =
+            LoginRequest(email: 'test@test.com', password: 'test-password');
+        final result = await authDatasourceImpl.login(request);
+
+        verify(() => mockDio.post(AuthApiPath.login)).called(1);
+
+        expect(result is Failure, true);
+        expect((result as Failure).message, "알 수 없는 에러가 발생했습니다.");
+      });
     });
   });
 }


### PR DESCRIPTION
## 작업내용

auth_datasource_impl.dart 내부에 로그인 엔드포인트를 제작했습니다.

서버로부터 토큰정보를 함께 가져옵니다. 실패시 에러 메시지를 반환합니다.

## 테스트
<img width="237" height="24" alt="스크린샷 2025-09-04 오전 10 48 30" src="https://github.com/user-attachments/assets/63ab5080-66b3-40a0-bbbb-1bd7bc511ef1" />

<img width="1196" height="94" alt="스크린샷 2025-09-04 오전 10 48 08" src="https://github.com/user-attachments/assets/f8292246-7284-408d-9ea8-a7e209ddf8b8" />
