### PR TITLE
Fix: CICD 워크플로우 빌드 환경을 MacOS 환경으로 변경

### DIFF
--- a/.github/workflows/dev-test-ci.yml
+++ b/.github/workflows/dev-test-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       # 1. 저장소 체크아웃


### PR DESCRIPTION
기존 워크플로우는 ubuntu 환경에서 골든 테스트를 함께 진행하는데, 이로인하여 작은 픽셀 에러로 인해 테스트 케이스 4개가 실패하는 것으로 추정됩니다. 따라서, 워크플로우 OS 를 macos로 변경하였습니다.

```yml

jobs:
  test:
    runs-on: macos-latest # macos로 변경
```