### PR TITLE
Feat: 이메일 인증 요청 유스케이스 생성

### DIFF
--- a/lib/src/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/src/features/auth/data/repositories/auth_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/locals/jwt_storage.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
 import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
@@ -55,6 +56,12 @@ class AuthRepositoryImpl extends AuthRepository {
   Future<Result<String>> checkEmailDuplicate(String email) {
     return _authDatasource
         .checkEmailDuplicate(CheckEmailDuplicateRequest(email: email));
+  }
+
+  @override
+  Future<Result<String>> sendVerificationEmail(String email) {
+    return _authDatasource
+        .sendVerificationEmail(EmailVerificationRequest(email: email));
   }
 
   /// 로그인을 수행합니다.

--- a/lib/src/features/auth/domain/entities/send_verification_email_info.dart
+++ b/lib/src/features/auth/domain/entities/send_verification_email_info.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'send_verification_email_info.freezed.dart';
+
+@freezed
+abstract class SendVerificationEmailInfo with _$SendVerificationEmailInfo {
+  const factory SendVerificationEmailInfo({
+    required String email,
+  }) = _SendVerificationEmailInfo;
+}

--- a/lib/src/features/auth/domain/entities/send_verification_email_info.freezed.dart
+++ b/lib/src/features/auth/domain/entities/send_verification_email_info.freezed.dart
@@ -1,0 +1,148 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'send_verification_email_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SendVerificationEmailInfo {
+  String get email;
+
+  /// Create a copy of SendVerificationEmailInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $SendVerificationEmailInfoCopyWith<SendVerificationEmailInfo> get copyWith =>
+      _$SendVerificationEmailInfoCopyWithImpl<SendVerificationEmailInfo>(
+          this as SendVerificationEmailInfo, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SendVerificationEmailInfo &&
+            (identical(other.email, email) || other.email == email));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email);
+
+  @override
+  String toString() {
+    return 'SendVerificationEmailInfo(email: $email)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $SendVerificationEmailInfoCopyWith<$Res> {
+  factory $SendVerificationEmailInfoCopyWith(SendVerificationEmailInfo value,
+          $Res Function(SendVerificationEmailInfo) _then) =
+      _$SendVerificationEmailInfoCopyWithImpl;
+  @useResult
+  $Res call({String email});
+}
+
+/// @nodoc
+class _$SendVerificationEmailInfoCopyWithImpl<$Res>
+    implements $SendVerificationEmailInfoCopyWith<$Res> {
+  _$SendVerificationEmailInfoCopyWithImpl(this._self, this._then);
+
+  final SendVerificationEmailInfo _self;
+  final $Res Function(SendVerificationEmailInfo) _then;
+
+  /// Create a copy of SendVerificationEmailInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+  }) {
+    return _then(_self.copyWith(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _SendVerificationEmailInfo implements SendVerificationEmailInfo {
+  const _SendVerificationEmailInfo({required this.email});
+
+  @override
+  final String email;
+
+  /// Create a copy of SendVerificationEmailInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SendVerificationEmailInfoCopyWith<_SendVerificationEmailInfo>
+      get copyWith =>
+          __$SendVerificationEmailInfoCopyWithImpl<_SendVerificationEmailInfo>(
+              this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _SendVerificationEmailInfo &&
+            (identical(other.email, email) || other.email == email));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email);
+
+  @override
+  String toString() {
+    return 'SendVerificationEmailInfo(email: $email)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$SendVerificationEmailInfoCopyWith<$Res>
+    implements $SendVerificationEmailInfoCopyWith<$Res> {
+  factory _$SendVerificationEmailInfoCopyWith(_SendVerificationEmailInfo value,
+          $Res Function(_SendVerificationEmailInfo) _then) =
+      __$SendVerificationEmailInfoCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String email});
+}
+
+/// @nodoc
+class __$SendVerificationEmailInfoCopyWithImpl<$Res>
+    implements _$SendVerificationEmailInfoCopyWith<$Res> {
+  __$SendVerificationEmailInfoCopyWithImpl(this._self, this._then);
+
+  final _SendVerificationEmailInfo _self;
+  final $Res Function(_SendVerificationEmailInfo) _then;
+
+  /// Create a copy of SendVerificationEmailInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+  }) {
+    return _then(_SendVerificationEmailInfo(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/src/features/auth/domain/repositories/auth_repository.dart
@@ -9,6 +9,8 @@ abstract class AuthRepository {
 
   Future<Result<void>> login(LoginInfo login);
 
+  Future<Result<String>> sendVerificationEmail(String email);
+
   Future<void> logout();
 
   Future<String?> getAccessToken();

--- a/lib/src/features/auth/domain/usecases/send_verification_email_usecase.dart
+++ b/lib/src/features/auth/domain/usecases/send_verification_email_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
+
+final class SendVerificationEmailUsecaseImpl
+    implements SendVerificationEmailUsecase {
+  final AuthRepository _authRepository;
+
+  const SendVerificationEmailUsecaseImpl({
+    required AuthRepository authRepository,
+  }) : _authRepository = authRepository;
+  @override
+  Future<Result<String>> call(String email) async {
+    return await _authRepository.sendVerificationEmail(email);
+  }
+}
+
+abstract class SendVerificationEmailUsecase {
+  Future<Result<String>> call(String email);
+}

--- a/test/feature/auth/data/repositories/auth_repository_impl_test.dart
+++ b/test/feature/auth/data/repositories/auth_repository_impl_test.dart
@@ -5,6 +5,7 @@ import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/locals/jwt_storage.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
 import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:solo_play_application/src/features/auth/data/repositories/auth_repository_impl.dart';
@@ -200,6 +201,40 @@ void main() {
         ).called(1);
 
         expect(accessToken, isNull);
+      });
+    });
+
+    group('when called sendVerificationEmail', () {
+      test('should return correctly when success', () async {
+        final email = "test@test.com";
+        final request = EmailVerificationRequest(email: email);
+        when(
+          () => mockAuthDatasource.sendVerificationEmail(request),
+        ).thenAnswer((_) async => Success('message'));
+
+        final result = await authRepository.sendVerificationEmail(email);
+
+        verify(
+          () => mockAuthDatasource.sendVerificationEmail(request),
+        ).called(1);
+
+        expect(result, isA<Success>());
+      });
+
+      test('should return correctly when failure', () async {
+        final email = "test@test.com";
+        final request = EmailVerificationRequest(email: email);
+        when(
+          () => mockAuthDatasource.sendVerificationEmail(request),
+        ).thenAnswer((_) async => Failure('error'));
+
+        final result = await authRepository.sendVerificationEmail(email);
+
+        verify(
+          () => mockAuthDatasource.sendVerificationEmail(request),
+        ).called(1);
+
+        expect(result, isA<Failure>());
       });
     });
   });

--- a/test/feature/auth/domain/usecases/send_verification_email_usecase_test.dart
+++ b/test/feature/auth/domain/usecases/send_verification_email_usecase_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late SendVerificationEmailUsecase usecase;
+  late MockAuthRepository mockAuthRepository;
+
+  setUp(() {
+    mockAuthRepository = MockAuthRepository();
+    usecase =
+        SendVerificationEmailUsecaseImpl(authRepository: mockAuthRepository);
+  });
+
+  const tEmail = 'test@test.com';
+
+  group(SendVerificationEmailUsecase, () {
+    test('should send verification email from the repository', () async {
+      // arrange
+      when(() => mockAuthRepository.sendVerificationEmail(any()))
+          .thenAnswer((_) async => const Success('Success'));
+      // act
+      final result = await usecase(tEmail);
+      // assert
+      expect(result, const Success('Success'));
+      verify(() => mockAuthRepository.sendVerificationEmail(tEmail));
+      verifyNoMoreInteractions(mockAuthRepository);
+    });
+  });
+}


### PR DESCRIPTION
## 작업내용

사용자가 이메일 인증을 요청하는 유스케이스를 생성했습니다.

```dart

final class SendVerificationEmailUsecaseImpl
    implements SendVerificationEmailUsecase {
  final AuthRepository _authRepository;

  const SendVerificationEmailUsecaseImpl({
    required AuthRepository authRepository,
  }) : _authRepository = authRepository;
  @override
  Future<Result<String>> call(String email) async {
    return await _authRepository.sendVerificationEmail(email);
  }
}

abstract class SendVerificationEmailUsecase {
  Future<Result<String>> call(String email);
}

AuthRepository의 구현체에서는 datasource의 이메일 인증 요청 메소드를 그대로 호출합니다.

```

## 테스트

<img width="243" height="21" alt="스크린샷 2025-09-20 오후 3 47 54" src="https://github.com/user-attachments/assets/4a0d865c-6547-429a-aff3-2a128d0fae16" />

아직은 예외처리에 대한 사항이 결정되지 않아 성공 케이스에 대해 테스트만 작성되어 케이스가 한개입니다.