### PR TITLE
Feat: 이메일 인증코드 검증 비즈니스 로직 제작

### DIFF
--- a/lib/src/features/auth/data/datasources/remotes/auth_datasource.dart
+++ b/lib/src/features/auth/data/datasources/remotes/auth_datasource.dart
@@ -4,6 +4,7 @@ import 'package:solo_play_application/src/features/auth/data/models/email_verifi
 import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:solo_play_application/src/features/auth/data/models/register_request.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 
 /// 인증 관련 원격 데이터 소스의 추상 클래스입니다.
 ///
@@ -37,5 +38,8 @@ abstract class AuthDatasource {
   /// ### 반환
   /// - [Success]<String> : 이메일 전송 성공 시 메시지 반환
   /// - [Failure]<String> : 이메일 전송 실패 시 메시지 반환
-  Future<Result<String>> sendVerificationEmail(EmailVerificationRequest request);
+  Future<Result<String>> sendVerificationEmail(
+      EmailVerificationRequest request);
+
+  Future<Result<String>> verifyCode(VerifyCodeRequest request);
 }

--- a/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
+++ b/lib/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart
@@ -8,6 +8,7 @@ import 'package:solo_play_application/src/features/auth/data/utils/api_path.dart
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
 import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 
 /// [AuthDatasource]의 구현체
 ///
@@ -151,6 +152,35 @@ class AuthDatasourceImpl extends AuthDatasource {
       final response = await _dio.post(
         AuthApiPath.sendVerificationEmail,
         data: request.toJson(), // request.toJson() 사용
+      );
+      if (response.statusCode == 200) {
+        return Success(response.data["message"] as String);
+      } else {
+        return Failure(response.data['message'] as String? ?? "알 수 없는 오류가 발생했습니다.");
+      }
+    } on DioException catch (e) {
+      if (e.response != null) {
+        final dynamic errorData = e.response!.data;
+        if (errorData is Map<String, dynamic> &&
+            errorData.containsKey('message')) {
+          return Failure(errorData['message'] as String);
+        } else {
+          return Failure("알 수 없는 서버 응답 형식입니다.");
+        }
+      } else {
+        return Failure("네트워크 연결을 확인해주세요.");
+      }
+    } catch (e) {
+      return Failure("예상치 못한 오류가 발생했습니다: ${e.toString()}");
+    }
+  }
+
+  @override
+  Future<Result<String>> verifyCode(VerifyCodeRequest request) async {
+    try {
+      final response = await _dio.post(
+        AuthApiPath.checkVerifyCode,
+        data: request.toJson(),
       );
       if (response.statusCode == 200) {
         return Success(response.data["message"] as String);

--- a/lib/src/features/auth/data/models/verify_code_request.dart
+++ b/lib/src/features/auth/data/models/verify_code_request.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verify_code_request.freezed.dart';
+part 'verify_code_request.g.dart';
+
+@freezed
+abstract class VerifyCodeRequest with _$VerifyCodeRequest {
+  const factory VerifyCodeRequest({
+    required String email,
+    required String code,
+  }) = _VerifyCodeRequest;
+
+  factory VerifyCodeRequest.fromJson(Map<String, dynamic> json) =>
+      _$VerifyCodeRequestFromJson(json);
+}

--- a/lib/src/features/auth/data/models/verify_code_request.freezed.dart
+++ b/lib/src/features/auth/data/models/verify_code_request.freezed.dart
@@ -1,0 +1,175 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'verify_code_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VerifyCodeRequest {
+  String get email;
+  String get code;
+
+  /// Create a copy of VerifyCodeRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $VerifyCodeRequestCopyWith<VerifyCodeRequest> get copyWith =>
+      _$VerifyCodeRequestCopyWithImpl<VerifyCodeRequest>(
+          this as VerifyCodeRequest, _$identity);
+
+  /// Serializes this VerifyCodeRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is VerifyCodeRequest &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.code, code) || other.code == code));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, email, code);
+
+  @override
+  String toString() {
+    return 'VerifyCodeRequest(email: $email, code: $code)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $VerifyCodeRequestCopyWith<$Res> {
+  factory $VerifyCodeRequestCopyWith(
+          VerifyCodeRequest value, $Res Function(VerifyCodeRequest) _then) =
+      _$VerifyCodeRequestCopyWithImpl;
+  @useResult
+  $Res call({String email, String code});
+}
+
+/// @nodoc
+class _$VerifyCodeRequestCopyWithImpl<$Res>
+    implements $VerifyCodeRequestCopyWith<$Res> {
+  _$VerifyCodeRequestCopyWithImpl(this._self, this._then);
+
+  final VerifyCodeRequest _self;
+  final $Res Function(VerifyCodeRequest) _then;
+
+  /// Create a copy of VerifyCodeRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? code = null,
+  }) {
+    return _then(_self.copyWith(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _VerifyCodeRequest implements VerifyCodeRequest {
+  const _VerifyCodeRequest({required this.email, required this.code});
+  factory _VerifyCodeRequest.fromJson(Map<String, dynamic> json) =>
+      _$VerifyCodeRequestFromJson(json);
+
+  @override
+  final String email;
+  @override
+  final String code;
+
+  /// Create a copy of VerifyCodeRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$VerifyCodeRequestCopyWith<_VerifyCodeRequest> get copyWith =>
+      __$VerifyCodeRequestCopyWithImpl<_VerifyCodeRequest>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$VerifyCodeRequestToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _VerifyCodeRequest &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.code, code) || other.code == code));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, email, code);
+
+  @override
+  String toString() {
+    return 'VerifyCodeRequest(email: $email, code: $code)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$VerifyCodeRequestCopyWith<$Res>
+    implements $VerifyCodeRequestCopyWith<$Res> {
+  factory _$VerifyCodeRequestCopyWith(
+          _VerifyCodeRequest value, $Res Function(_VerifyCodeRequest) _then) =
+      __$VerifyCodeRequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String email, String code});
+}
+
+/// @nodoc
+class __$VerifyCodeRequestCopyWithImpl<$Res>
+    implements _$VerifyCodeRequestCopyWith<$Res> {
+  __$VerifyCodeRequestCopyWithImpl(this._self, this._then);
+
+  final _VerifyCodeRequest _self;
+  final $Res Function(_VerifyCodeRequest) _then;
+
+  /// Create a copy of VerifyCodeRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+    Object? code = null,
+  }) {
+    return _then(_VerifyCodeRequest(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/features/auth/data/models/verify_code_request.g.dart
+++ b/lib/src/features/auth/data/models/verify_code_request.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'verify_code_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VerifyCodeRequest _$VerifyCodeRequestFromJson(Map<String, dynamic> json) =>
+    _VerifyCodeRequest(
+      email: json['email'] as String,
+      code: json['code'] as String,
+    );
+
+Map<String, dynamic> _$VerifyCodeRequestToJson(_VerifyCodeRequest instance) =>
+    <String, dynamic>{
+      'email': instance.email,
+      'code': instance.code,
+    };

--- a/lib/src/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/src/features/auth/data/repositories/auth_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:solo_play_application/src/features/auth/data/models/check_email_
 import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
 import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 
@@ -62,6 +63,11 @@ class AuthRepositoryImpl extends AuthRepository {
   Future<Result<String>> sendVerificationEmail(String email) {
     return _authDatasource
         .sendVerificationEmail(EmailVerificationRequest(email: email));
+  }
+
+  @override
+  Future<Result<String>> verifyCode(VerifyCodeRequest request) {
+    return _authDatasource.verifyCode(request);
   }
 
   /// 로그인을 수행합니다.

--- a/lib/src/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/src/features/auth/data/repositories/auth_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/verify_code_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 
 enum AuthenticateStatus { unknown, authenticated, unauthenticated }
@@ -66,8 +67,9 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
-  Future<Result<String>> verifyCode(VerifyCodeRequest request) {
-    return _authDatasource.verifyCode(request);
+  Future<Result<String>> verifyCode(VerifyCodeInfo request) {
+    return _authDatasource.verifyCode(
+        VerifyCodeRequest(email: request.email, code: request.code));
   }
 
   /// 로그인을 수행합니다.

--- a/lib/src/features/auth/data/utils/api_path.dart
+++ b/lib/src/features/auth/data/utils/api_path.dart
@@ -3,6 +3,5 @@ class AuthApiPath {
   static const String checkEmailDuplicate = "$path/check-email-duplicate";
   static const String login = "$path/login";
   static const String signup = "$path/signup";
-  static const String sendVerificationEmail = "$path/send-verification-email";
+  static const String sendVerificationEmail = "$path/email-verify";
 }
-

--- a/lib/src/features/auth/data/utils/api_path.dart
+++ b/lib/src/features/auth/data/utils/api_path.dart
@@ -4,4 +4,5 @@ class AuthApiPath {
   static const String login = "$path/login";
   static const String signup = "$path/signup";
   static const String sendVerificationEmail = "$path/email-verify";
+  static const String checkVerifyCode = "$path/email-confirm";
 }

--- a/lib/src/features/auth/domain/entities/verify_code_info.dart
+++ b/lib/src/features/auth/domain/entities/verify_code_info.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verify_code_info.freezed.dart';
+
+@freezed
+abstract class VerifyCodeInfo with _$VerifyCodeInfo {
+  const factory VerifyCodeInfo({
+    required String email,
+    required String code,
+  }) = _VerifyCodeInfo;
+
+  const VerifyCodeInfo._();
+}

--- a/lib/src/features/auth/domain/entities/verify_code_info.freezed.dart
+++ b/lib/src/features/auth/domain/entities/verify_code_info.freezed.dart
@@ -1,0 +1,161 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'verify_code_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VerifyCodeInfo {
+  String get email;
+  String get code;
+
+  /// Create a copy of VerifyCodeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $VerifyCodeInfoCopyWith<VerifyCodeInfo> get copyWith =>
+      _$VerifyCodeInfoCopyWithImpl<VerifyCodeInfo>(
+          this as VerifyCodeInfo, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is VerifyCodeInfo &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.code, code) || other.code == code));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, code);
+
+  @override
+  String toString() {
+    return 'VerifyCodeInfo(email: $email, code: $code)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $VerifyCodeInfoCopyWith<$Res> {
+  factory $VerifyCodeInfoCopyWith(
+          VerifyCodeInfo value, $Res Function(VerifyCodeInfo) _then) =
+      _$VerifyCodeInfoCopyWithImpl;
+  @useResult
+  $Res call({String email, String code});
+}
+
+/// @nodoc
+class _$VerifyCodeInfoCopyWithImpl<$Res>
+    implements $VerifyCodeInfoCopyWith<$Res> {
+  _$VerifyCodeInfoCopyWithImpl(this._self, this._then);
+
+  final VerifyCodeInfo _self;
+  final $Res Function(VerifyCodeInfo) _then;
+
+  /// Create a copy of VerifyCodeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? code = null,
+  }) {
+    return _then(_self.copyWith(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _VerifyCodeInfo extends VerifyCodeInfo {
+  const _VerifyCodeInfo({required this.email, required this.code}) : super._();
+
+  @override
+  final String email;
+  @override
+  final String code;
+
+  /// Create a copy of VerifyCodeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$VerifyCodeInfoCopyWith<_VerifyCodeInfo> get copyWith =>
+      __$VerifyCodeInfoCopyWithImpl<_VerifyCodeInfo>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _VerifyCodeInfo &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.code, code) || other.code == code));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, code);
+
+  @override
+  String toString() {
+    return 'VerifyCodeInfo(email: $email, code: $code)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$VerifyCodeInfoCopyWith<$Res>
+    implements $VerifyCodeInfoCopyWith<$Res> {
+  factory _$VerifyCodeInfoCopyWith(
+          _VerifyCodeInfo value, $Res Function(_VerifyCodeInfo) _then) =
+      __$VerifyCodeInfoCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String email, String code});
+}
+
+/// @nodoc
+class __$VerifyCodeInfoCopyWithImpl<$Res>
+    implements _$VerifyCodeInfoCopyWith<$Res> {
+  __$VerifyCodeInfoCopyWithImpl(this._self, this._then);
+
+  final _VerifyCodeInfo _self;
+  final $Res Function(_VerifyCodeInfo) _then;
+
+  /// Create a copy of VerifyCodeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+    Object? code = null,
+  }) {
+    return _then(_VerifyCodeInfo(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/src/features/auth/domain/repositories/auth_repository.dart
@@ -1,6 +1,7 @@
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 
 abstract class AuthRepository {
   Stream<AuthenticateStatus> get authStatusStream;
@@ -10,6 +11,8 @@ abstract class AuthRepository {
   Future<Result<void>> login(LoginInfo login);
 
   Future<Result<String>> sendVerificationEmail(String email);
+
+  Future<Result<String>> verifyCode(VerifyCodeRequest request);
 
   Future<void> logout();
 

--- a/lib/src/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/src/features/auth/domain/repositories/auth_repository.dart
@@ -1,7 +1,7 @@
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
-import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/verify_code_info.dart';
 
 abstract class AuthRepository {
   Stream<AuthenticateStatus> get authStatusStream;
@@ -12,7 +12,7 @@ abstract class AuthRepository {
 
   Future<Result<String>> sendVerificationEmail(String email);
 
-  Future<Result<String>> verifyCode(VerifyCodeRequest request);
+  Future<Result<String>> verifyCode(VerifyCodeInfo request);
 
   Future<void> logout();
 

--- a/lib/src/features/auth/domain/usecases/user_verify_code_usecase.dart
+++ b/lib/src/features/auth/domain/usecases/user_verify_code_usecase.dart
@@ -1,18 +1,20 @@
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
-import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/verify_code_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 
 abstract class UserVerifyCodeUsecase {
-  Future<Result<String>> call(VerifyCodeRequest request);
+  Future<Result<String>> call(String email, String code);
 }
 
 class UserVerifyCodeUsecaseImpl extends UserVerifyCodeUsecase {
-  final AuthRepository _repository;
+  final AuthRepository _authRepository;
 
-  UserVerifyCodeUsecaseImpl({required AuthRepository repository}) : _repository = repository;
+  UserVerifyCodeUsecaseImpl({required AuthRepository authRepository})
+      : _authRepository = authRepository;
 
   @override
-  Future<Result<String>> call(VerifyCodeRequest request) async {
-    return await _repository.verifyCode(request);
+  Future<Result<String>> call(String email, String code) async {
+    final verifyCodeInfo = VerifyCodeInfo(email: email, code: code);
+    return await _authRepository.verifyCode(verifyCodeInfo);
   }
 }

--- a/lib/src/features/auth/domain/usecases/user_verify_code_usecase.dart
+++ b/lib/src/features/auth/domain/usecases/user_verify_code_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
+
+abstract class UserVerifyCodeUsecase {
+  Future<Result<String>> call(VerifyCodeRequest request);
+}
+
+class UserVerifyCodeUsecaseImpl extends UserVerifyCodeUsecase {
+  final AuthRepository _repository;
+
+  UserVerifyCodeUsecaseImpl({required AuthRepository repository}) : _repository = repository;
+
+  @override
+  Future<Result<String>> call(VerifyCodeRequest request) async {
+    return await _repository.verifyCode(request);
+  }
+}

--- a/lib/src/features/auth/presentation/verification/bloc/verification_bloc.dart
+++ b/lib/src/features/auth/presentation/verification/bloc/verification_bloc.dart
@@ -3,18 +3,23 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 
 class VerificationBloc extends Bloc<VerificationEvent, VerificationState> {
   final SendVerificationEmailUsecase _sendVerificationEmailUsecase;
+  final UserVerifyCodeUsecase _userVerifyCodeUsecase;
 
   VerificationBloc({
     required SendVerificationEmailUsecase sendVerificationEmailUsecase,
+    required UserVerifyCodeUsecase userVerifyCodeUsecase,
   })  : _sendVerificationEmailUsecase = sendVerificationEmailUsecase,
+        _userVerifyCodeUsecase = userVerifyCodeUsecase,
         super(const VerificationState()) {
     on<VerificationCodeChanged>(_onCodeChanged);
     on<VerificationEmailSent>(_onVerificationEmailSent);
+    on<VerificationSubmitted>(_onVerificationSubmitted);
   }
 
   FutureOr<void> _onCodeChanged(
@@ -33,6 +38,23 @@ class VerificationBloc extends Bloc<VerificationEvent, VerificationState> {
     switch (result) {
       case Success():
         emit(state.copyWith(status: VerificationStatus.sent));
+      case Failure():
+        emit(state.copyWith(
+          status: VerificationStatus.error,
+          errorMessage: result.message,
+        ));
+    }
+  }
+
+  FutureOr<void> _onVerificationSubmitted(
+    VerificationSubmitted event,
+    Emitter<VerificationState> emit,
+  ) async {
+    emit(state.copyWith(status: VerificationStatus.verifying));
+    final result = await _userVerifyCodeUsecase.call(event.email, event.code);
+    switch (result) {
+      case Success():
+        emit(state.copyWith(status: VerificationStatus.verified));
       case Failure():
         emit(state.copyWith(
           status: VerificationStatus.error,

--- a/lib/src/features/auth/presentation/verification/bloc/verification_event.dart
+++ b/lib/src/features/auth/presentation/verification/bloc/verification_event.dart
@@ -8,4 +8,6 @@ sealed class VerificationEvent with _$VerificationEvent {
       VerificationCodeChanged;
   const factory VerificationEvent.verificationEmailSent(String email) =
       VerificationEmailSent;
+  const factory VerificationEvent.verificationSubmitted(String email, String code) =
+      VerificationSubmitted;
 }

--- a/lib/src/features/auth/presentation/verification/bloc/verification_event.freezed.dart
+++ b/lib/src/features/auth/presentation/verification/bloc/verification_event.freezed.dart
@@ -166,4 +166,76 @@ class _$VerificationEmailSentCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
+
+class VerificationSubmitted implements VerificationEvent {
+  const VerificationSubmitted(this.email, this.code);
+
+  final String email;
+  final String code;
+
+  /// Create a copy of VerificationEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $VerificationSubmittedCopyWith<VerificationSubmitted> get copyWith =>
+      _$VerificationSubmittedCopyWithImpl<VerificationSubmitted>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is VerificationSubmitted &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.code, code) || other.code == code));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, code);
+
+  @override
+  String toString() {
+    return 'VerificationEvent.verificationSubmitted(email: $email, code: $code)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $VerificationSubmittedCopyWith<$Res>
+    implements $VerificationEventCopyWith<$Res> {
+  factory $VerificationSubmittedCopyWith(VerificationSubmitted value,
+          $Res Function(VerificationSubmitted) _then) =
+      _$VerificationSubmittedCopyWithImpl;
+  @useResult
+  $Res call({String email, String code});
+}
+
+/// @nodoc
+class _$VerificationSubmittedCopyWithImpl<$Res>
+    implements $VerificationSubmittedCopyWith<$Res> {
+  _$VerificationSubmittedCopyWithImpl(this._self, this._then);
+
+  final VerificationSubmitted _self;
+  final $Res Function(VerificationSubmitted) _then;
+
+  /// Create a copy of VerificationEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+    Object? code = null,
+  }) {
+    return _then(VerificationSubmitted(
+      null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
 // dart format on

--- a/lib/src/features/auth/presentation/verification/bloc/verification_state.dart
+++ b/lib/src/features/auth/presentation/verification/bloc/verification_state.dart
@@ -2,7 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'verification_state.freezed.dart';
 
-enum VerificationStatus { initial, sending, sent, error }
+enum VerificationStatus { initial, sending, sent, error, verifying, verified }
 
 @freezed
 abstract class VerificationState with _$VerificationState {

--- a/lib/src/features/auth/presentation/verification/pages/verification_email_page.dart
+++ b/lib/src/features/auth/presentation/verification/pages/verification_email_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/views/verification_email_ui.dart';
 import 'package:solo_play_application/src/features/timer/bloc/timer_bloc.dart';
@@ -18,8 +19,12 @@ class VerificationEmailPage extends StatelessWidget {
         RepositoryProvider<SendVerificationEmailUsecase>(
             create: (context) => SendVerificationEmailUsecaseImpl(
                 authRepository: context.read<AuthRepository>())),
+        RepositoryProvider<UserVerifyCodeUsecase>(
+            create: (context) => UserVerifyCodeUsecaseImpl(
+                authRepository: context.read<AuthRepository>())),
         BlocProvider<VerificationBloc>(
           create: (context) => VerificationBloc(
+            userVerifyCodeUsecase: context.read<UserVerifyCodeUsecase>(),
             sendVerificationEmailUsecase:
                 context.read<SendVerificationEmailUsecase>(),
           ),

--- a/test/feature/auth/data/datasources/remotes/auth_datasource_impl_test.dart
+++ b/test/feature/auth/data/datasources/remotes/auth_datasource_impl_test.dart
@@ -1,0 +1,53 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
+import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/data/utils/api_path.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  late Dio mockDio;
+  late AuthDatasource datasource;
+
+  setUp(() {
+    mockDio = MockDio();
+    datasource = AuthDatasourceImpl(dio: mockDio);
+  });
+
+  group('verifyCode', () {
+    const verifyCodeRequest = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+    final successResponse = {
+      'message': '인증에 성공했습니다.',
+    };
+
+    test('should return Success(String) when the call is successful', () async {
+      // Arrange
+      when(() => mockDio.post(
+            AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson(),
+          )).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
+          data: successResponse,
+          statusCode: 200,
+        ),
+      );
+
+      // Act
+      final result = await datasource.verifyCode(verifyCodeRequest);
+
+      // Assert
+      expect(result, isA<Success>());
+      expect((result as Success).value, successResponse['message']);
+      verify(() => mockDio.post(
+            AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson(),
+          )).called(1);
+      verifyNoMoreInteractions(mockDio);
+    });
+  });
+}

--- a/test/feature/auth/data/repositories/auth_repository_impl_test.dart
+++ b/test/feature/auth/data/repositories/auth_repository_impl_test.dart
@@ -8,6 +8,7 @@ import 'package:solo_play_application/src/features/auth/data/models/check_email_
 import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
 import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
 import 'package:solo_play_application/src/features/auth/data/models/login.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 import 'package:solo_play_application/src/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
@@ -232,6 +233,38 @@ void main() {
 
         verify(
           () => mockAuthDatasource.sendVerificationEmail(request),
+        ).called(1);
+
+        expect(result, isA<Failure>());
+      });
+    });
+
+    group('when called verifyCode', () {
+      test('should return correctly when success', () async {
+        final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+        when(
+          () => mockAuthDatasource.verifyCode(request),
+        ).thenAnswer((_) async => Success('message'));
+
+        final result = await authRepository.verifyCode(request);
+
+        verify(
+          () => mockAuthDatasource.verifyCode(request),
+        ).called(1);
+
+        expect(result, isA<Success>());
+      });
+
+      test('should return correctly when failure', () async {
+        final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+        when(
+          () => mockAuthDatasource.verifyCode(request),
+        ).thenAnswer((_) async => Failure('error'));
+
+        final result = await authRepository.verifyCode(request);
+
+        verify(
+          () => mockAuthDatasource.verifyCode(request),
         ).called(1);
 
         expect(result, isA<Failure>());

--- a/test/feature/auth/data/repositories/auth_repository_impl_test.dart
+++ b/test/feature/auth/data/repositories/auth_repository_impl_test.dart
@@ -11,6 +11,7 @@ import 'package:solo_play_application/src/features/auth/data/models/login.dart';
 import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 import 'package:solo_play_application/src/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/login_info.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/verify_code_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:test/test.dart';
 
@@ -29,6 +30,7 @@ void main() {
       mockAuthDatasource = MockAuthDatasource();
       mockJwtStorage = MockJwtStorage();
       tokenController = StreamController<String?>.broadcast();
+      registerFallbackValue(VerifyCodeRequest(email: '', code: ''));
 
       // Mock the tokenStream getter
       when(() => mockJwtStorage.tokenStream)
@@ -240,31 +242,32 @@ void main() {
     });
 
     group('when called verifyCode', () {
+      final verifyCodeInfo = VerifyCodeInfo(email: 'test@test.com', code: '123456');
+      final verifyCodeRequest = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+
       test('should return correctly when success', () async {
-        final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
         when(
-          () => mockAuthDatasource.verifyCode(request),
+          () => mockAuthDatasource.verifyCode(any()),
         ).thenAnswer((_) async => Success('message'));
 
-        final result = await authRepository.verifyCode(request);
+        final result = await authRepository.verifyCode(verifyCodeInfo);
 
         verify(
-          () => mockAuthDatasource.verifyCode(request),
+          () => mockAuthDatasource.verifyCode(verifyCodeRequest),
         ).called(1);
 
         expect(result, isA<Success>());
       });
 
       test('should return correctly when failure', () async {
-        final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
         when(
-          () => mockAuthDatasource.verifyCode(request),
+          () => mockAuthDatasource.verifyCode(any()),
         ).thenAnswer((_) async => Failure('error'));
 
-        final result = await authRepository.verifyCode(request);
+        final result = await authRepository.verifyCode(verifyCodeInfo);
 
         verify(
-          () => mockAuthDatasource.verifyCode(request),
+          () => mockAuthDatasource.verifyCode(verifyCodeRequest),
         ).called(1);
 
         expect(result, isA<Failure>());

--- a/test/feature/auth/domain/usecases/user_verify_code_usecase_test.dart
+++ b/test/feature/auth/domain/usecases/user_verify_code_usecase_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late UserVerifyCodeUsecase usecase;
+  late MockAuthRepository mockAuthRepository;
+
+  setUp(() {
+    mockAuthRepository = MockAuthRepository();
+    usecase = UserVerifyCodeUsecaseImpl(repository: mockAuthRepository);
+  });
+
+  group('UserVerifyCodeUsecase', () {
+    final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+
+    test('should call repository.verifyCode and return success', () async {
+      // Arrange
+      when(() => mockAuthRepository.verifyCode(request))
+          .thenAnswer((_) async => Success('message'));
+
+      // Act
+      final result = await usecase.call(request);
+
+      // Assert
+      expect(result, isA<Success>());
+      verify(() => mockAuthRepository.verifyCode(request)).called(1);
+      verifyNoMoreInteractions(mockAuthRepository);
+    });
+
+    test('should call repository.verifyCode and return failure', () async {
+      // Arrange
+      when(() => mockAuthRepository.verifyCode(request))
+          .thenAnswer((_) async => Failure('error'));
+
+      // Act
+      final result = await usecase.call(request);
+
+      // Assert
+      expect(result, isA<Failure>());
+      verify(() => mockAuthRepository.verifyCode(request)).called(1);
+      verifyNoMoreInteractions(mockAuthRepository);
+    });
+  });
+}

--- a/test/feature/auth/domain/usecases/user_verify_code_usecase_test.dart
+++ b/test/feature/auth/domain/usecases/user_verify_code_usecase_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
-import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/verify_code_info.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
 
@@ -13,37 +13,39 @@ void main() {
 
   setUp(() {
     mockAuthRepository = MockAuthRepository();
-    usecase = UserVerifyCodeUsecaseImpl(repository: mockAuthRepository);
+    usecase = UserVerifyCodeUsecaseImpl(authRepository: mockAuthRepository);
+    registerFallbackValue(VerifyCodeInfo(email: '', code: ''));
   });
 
   group('UserVerifyCodeUsecase', () {
-    final request = VerifyCodeRequest(email: 'test@test.com', code: '123456');
+    const email = 'test@test.com';
+    const code = '123456';
 
     test('should call repository.verifyCode and return success', () async {
       // Arrange
-      when(() => mockAuthRepository.verifyCode(request))
+      when(() => mockAuthRepository.verifyCode(any()))
           .thenAnswer((_) async => Success('message'));
 
       // Act
-      final result = await usecase.call(request);
+      final result = await usecase.call(email, code);
 
       // Assert
       expect(result, isA<Success>());
-      verify(() => mockAuthRepository.verifyCode(request)).called(1);
+      verify(() => mockAuthRepository.verifyCode(any())).called(1);
       verifyNoMoreInteractions(mockAuthRepository);
     });
 
     test('should call repository.verifyCode and return failure', () async {
       // Arrange
-      when(() => mockAuthRepository.verifyCode(request))
+      when(() => mockAuthRepository.verifyCode(any()))
           .thenAnswer((_) async => Failure('error'));
 
       // Act
-      final result = await usecase.call(request);
+      final result = await usecase.call(email, code);
 
       // Assert
       expect(result, isA<Failure>());
-      verify(() => mockAuthRepository.verifyCode(request)).called(1);
+      verify(() => mockAuthRepository.verifyCode(any())).called(1);
       verifyNoMoreInteractions(mockAuthRepository);
     });
   });

--- a/test/feature/auth/presentation/verification/bloc/verification_bloc_test.dart
+++ b/test/feature/auth/presentation/verification/bloc/verification_bloc_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
@@ -10,15 +11,20 @@ import 'package:solo_play_application/src/features/auth/presentation/verificatio
 class MockSendVerificationEmailUsecase extends Mock
     implements SendVerificationEmailUsecase {}
 
+class MockUserVerifyCodeUsecase extends Mock implements UserVerifyCodeUsecase {}
+
 void main() {
-  group('VerificationBloc', () {
+  group(VerificationBloc, () {
     late VerificationBloc verificationBloc;
     late MockSendVerificationEmailUsecase mockSendVerificationEmailUsecase;
+    late MockUserVerifyCodeUsecase mockUserVerifyCodeUsecase;
 
     setUp(() {
       mockSendVerificationEmailUsecase = MockSendVerificationEmailUsecase();
+      mockUserVerifyCodeUsecase = MockUserVerifyCodeUsecase();
       verificationBloc = VerificationBloc(
         sendVerificationEmailUsecase: mockSendVerificationEmailUsecase,
+        userVerifyCodeUsecase: mockUserVerifyCodeUsecase,
       );
     });
 
@@ -70,8 +76,46 @@ void main() {
           verify(() => mockSendVerificationEmailUsecase.call(email)).called(1);
         },
       );
+    });
 
-      
+    group('VerificationSubmitted', () {
+      const email = 'test@test.com';
+      const code = '123456';
+
+      blocTest<VerificationBloc, VerificationState>(
+        'emits [verifying, verified] states for successful code verification',
+        build: () {
+          when(() => mockUserVerifyCodeUsecase.call(email, code))
+              .thenAnswer((_) async => const Result.success(''));
+          return verificationBloc;
+        },
+        act: (bloc) => bloc.add(VerificationSubmitted(email, code)),
+        expect: () => [
+          const VerificationState(status: VerificationStatus.verifying),
+          const VerificationState(status: VerificationStatus.verified),
+        ],
+        verify: (_) {
+          verify(() => mockUserVerifyCodeUsecase.call(email, code)).called(1);
+        },
+      );
+
+      blocTest<VerificationBloc, VerificationState>(
+        'emits [verifying, error] states for usecase failure',
+        build: () {
+          when(() => mockUserVerifyCodeUsecase.call(email, code))
+              .thenAnswer((_) async => const Result.failure('Test Failure'));
+          return verificationBloc;
+        },
+        act: (bloc) => bloc.add(VerificationSubmitted(email, code)),
+        expect: () => [
+          const VerificationState(status: VerificationStatus.verifying),
+          const VerificationState(
+              status: VerificationStatus.error, errorMessage: 'Test Failure'),
+        ],
+        verify: (_) {
+          verify(() => mockUserVerifyCodeUsecase.call(email, code)).called(1);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## 작업내용

- 이메일 인증 API 제작

```dart
  @override
  Future<Result<String>> verifyCode(VerifyCodeRequest request) async {
    try {
      final response = await _dio.post(
        AuthApiPath.checkVerifyCode,
        data: request.toJson(),
      );
      if (response.statusCode == 200) {
        return Success(response.data["message"] as String);
      } else {
        return Failure(response.data['message'] as String? ?? "알 수 없는 오류가 발생했습니다.");
      }
    } on DioException catch (e) {
      if (e.response != null) {
        final dynamic errorData = e.response!.data;
        if (errorData is Map<String, dynamic> &&
            errorData.containsKey('message')) {
          return Failure(errorData['message'] as String);
        } else {
          return Failure("알 수 없는 서버 응답 형식입니다.");
        }
      } else {
        return Failure("네트워크 연결을 확인해주세요.");
      }
    } catch (e) {
      return Failure("예상치 못한 오류가 발생했습니다: ${e.toString()}");
    }
  }
```

- 이메일 인증 Repository 핸들러 제작

```dart
  @override
  Future<Result<String>> verifyCode(VerifyCodeInfo request) {
    return _authDatasource.verifyCode(
        VerifyCodeRequest(email: request.email, code: request.code));
  }

```

- 이메일 인증 Usecase 제작

```dart
abstract class UserVerifyCodeUsecase {
  Future<Result<String>> call(String email, String code);
}

class UserVerifyCodeUsecaseImpl extends UserVerifyCodeUsecase {
  final AuthRepository _authRepository;

  UserVerifyCodeUsecaseImpl({required AuthRepository authRepository})
      : _authRepository = authRepository;

  @override
  Future<Result<String>> call(String email, String code) async {
    final verifyCodeInfo = VerifyCodeInfo(email: email, code: code);
    return await _authRepository.verifyCode(verifyCodeInfo);
  }
}

```

- 이메일 인증 요청 이벤트 생성 및 핸들링 제작

```dart
  FutureOr<void> _onVerificationSubmitted(
    VerificationSubmitted event,
    Emitter<VerificationState> emit,
  ) async {
    emit(state.copyWith(status: VerificationStatus.verifying));
    final result = await _userVerifyCodeUsecase.call(event.email, event.code);
    switch (result) {
      case Success():
        emit(state.copyWith(status: VerificationStatus.verified));
      case Failure():
        emit(state.copyWith(
          status: VerificationStatus.error,
          errorMessage: result.message,
        ));
    }
  }
```

## 테스트

<img width="254" height="18" alt="스크린샷 2025-09-22 오후 2 30 38" src="https://github.com/user-attachments/assets/38655b0e-1430-43c2-bae9-7480b987b522" />


