### PR TITLE
Test: auth 모델 단위 테스트 추가

### DIFF
--- a/lib/src/features/auth/data/models/register_request.dart
+++ b/lib/src/features/auth/data/models/register_request.dart
@@ -5,8 +5,9 @@ import 'package:solo_play_application/src/features/auth/data/models/user_agreeme
 part 'register_request.freezed.dart';
 part 'register_request.g.dart';
 
-@Freezed(genericArgumentFactories: true)
+@freezed
 abstract class RegisterRequest with _$RegisterRequest {
+  @JsonSerializable(explicitToJson: true)
   const factory RegisterRequest({
     required UserAgreement userAgreement,
     required String email,

--- a/lib/src/features/auth/data/models/register_request.freezed.dart
+++ b/lib/src/features/auth/data/models/register_request.freezed.dart
@@ -120,19 +120,16 @@ class _$RegisterRequestCopyWithImpl<$Res>
 }
 
 /// @nodoc
-@JsonSerializable()
+
+@JsonSerializable(explicitToJson: true)
 class _RegisterRequest implements RegisterRequest {
   const _RegisterRequest(
       {required this.userAgreement,
       required this.email,
       required this.password,
       required this.code});
-  factory _RegisterRequest.fromJson(
-    Map<String, dynamic> json,
-  ) =>
-      _$RegisterRequestFromJson(
-        json,
-      );
+  factory _RegisterRequest.fromJson(Map<String, dynamic> json) =>
+      _$RegisterRequestFromJson(json);
 
   @override
   final UserAgreement userAgreement;

--- a/lib/src/features/auth/data/models/register_request.g.dart
+++ b/lib/src/features/auth/data/models/register_request.g.dart
@@ -17,7 +17,7 @@ _RegisterRequest _$RegisterRequestFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$RegisterRequestToJson(_RegisterRequest instance) =>
     <String, dynamic>{
-      'userAgreement': instance.userAgreement,
+      'userAgreement': instance.userAgreement.toJson(),
       'email': instance.email,
       'password': instance.password,
       'code': instance.code,

--- a/test/feature/auth/data/datasources/remotes/auth_datasource_impl_test.dart
+++ b/test/feature/auth/data/datasources/remotes/auth_datasource_impl_test.dart
@@ -4,6 +4,12 @@ import 'package:mocktail/mocktail.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource.dart';
 import 'package:solo_play_application/src/features/auth/data/datasources/remotes/auth_datasource_impl.dart';
+import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
+import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
+import 'package:solo_play_application/src/features/auth/data/models/login.dart';
+import 'package:solo_play_application/src/features/auth/data/models/register_request.dart';
+import 'package:solo_play_application/src/features/auth/data/models/user_agreement.dart';
 import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
 import 'package:solo_play_application/src/features/auth/data/utils/api_path.dart';
 
@@ -18,36 +24,536 @@ void main() {
     datasource = AuthDatasourceImpl(dio: mockDio);
   });
 
-  group('verifyCode', () {
-    const verifyCodeRequest = VerifyCodeRequest(email: 'test@test.com', code: '123456');
-    final successResponse = {
-      'message': '인증에 성공했습니다.',
-    };
+  group(AuthDatasourceImpl, () {
+    group('checkEmailDuplicate', () {
+      const email = 'test@test.com';
+      final request = CheckEmailDuplicateRequest(email: email);
+      final successResponse = {'message': '사용 가능한 이메일입니다.'};
 
-    test('should return Success(String) when the call is successful', () async {
-      // Arrange
-      when(() => mockDio.post(
-            AuthApiPath.checkVerifyCode,
-            data: verifyCodeRequest.toJson(),
-          )).thenAnswer(
-        (_) async => Response(
-          requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
-          data: successResponse,
-          statusCode: 200,
-        ),
-      );
+      test('should return Success(String) when the call is successful (200 OK)',
+          () async {
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenAnswer((_) async => Response(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                data: successResponse,
+                statusCode: 200));
 
-      // Act
-      final result = await datasource.verifyCode(verifyCodeRequest);
+        final result = await datasource.checkEmailDuplicate(request);
 
-      // Assert
-      expect(result, isA<Success>());
-      expect((result as Success).value, successResponse['message']);
-      verify(() => mockDio.post(
-            AuthApiPath.checkVerifyCode,
-            data: verifyCodeRequest.toJson(),
-          )).called(1);
-      verifyNoMoreInteractions(mockDio);
+        expect(result, isA<Success>());
+        expect((result as Success).value, successResponse['message']);
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+
+      test(
+          'should return Failure(String) when status code is 409 (Email duplicated)',
+          () async {
+        final errorResponse = {'message': '이미 사용 중인 이메일입니다.'};
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 409,
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                response: Response(
+                    requestOptions:
+                        RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                    data: errorResponse,
+                    statusCode: 409)));
+
+        final result = await datasource.checkEmailDuplicate(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for 400 or 500 status codes',
+          () async {
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 400,
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                response: Response(
+                    requestOptions:
+                        RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                    data: {},
+                    statusCode: 400)));
+
+        final result = await datasource.checkEmailDuplicate(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '알 수 없는 오류가 발생했습니다.');
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for other DioException status codes',
+          () async {
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 404,
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                response: Response(
+                    requestOptions:
+                        RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                    data: {},
+                    statusCode: 404)));
+
+        final result = await datasource.checkEmailDuplicate(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '서버와의 연결이 원할하지 않습니다');
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for network error (no response)',
+          () async {
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenThrow(DioException(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkEmailDuplicate),
+                type: DioExceptionType.connectionError));
+
+        final result = await datasource.checkEmailDuplicate(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '네트워크 연결을 확인해주세요.');
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for unexpected error', () async {
+        when(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+                queryParameters: request.toJson()))
+            .thenThrow(Exception('Some unexpected error'));
+
+        final result = await datasource.checkEmailDuplicate(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, contains('예상치 못한 오류가 발생했습니다'));
+        verify(() => mockDio.get(AuthApiPath.checkEmailDuplicate,
+            queryParameters: request.toJson())).called(1);
+      });
+    });
+
+    // --- login tests ---
+    group('login', () {
+      final request =
+          LoginRequest(email: 'test@test.com', password: 'password');
+      final jwtResponse = {
+        'data': {
+          'accessToken': 'abc',
+          'refreshToken': 'def',
+          'grantType': 'Bearer'
+        }
+      };
+
+      test('should return Success(Jwt) when the call is successful', () async {
+        when(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .thenAnswer((_) async => Response(
+                requestOptions: RequestOptions(path: AuthApiPath.login),
+                data: jwtResponse,
+                statusCode: 200));
+
+        final result = await datasource.login(request);
+
+        expect(result, isA<Success>());
+        expect((result as Success).value, isA<Jwt>());
+        expect((result as Success).value.accessToken, 'abc');
+        verify(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) when DioException has message',
+          () async {
+        final errorResponse = {'message': 'Invalid credentials'};
+        when(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 401,
+                requestOptions: RequestOptions(path: AuthApiPath.login),
+                response: Response(
+                    requestOptions: RequestOptions(path: AuthApiPath.login),
+                    data: errorResponse,
+                    statusCode: 401)));
+
+        final result = await datasource.login(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for unknown server response format',
+          () async {
+        when(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 401,
+                requestOptions: RequestOptions(path: AuthApiPath.login),
+                response: Response(
+                    requestOptions: RequestOptions(path: AuthApiPath.login),
+                    data: 'not a map',
+                    statusCode: 401)));
+
+        final result = await datasource.login(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '알 수 없는 서버 응답 형식입니다.');
+        verify(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for network error (no response)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .thenThrow(DioException(
+                requestOptions: RequestOptions(path: AuthApiPath.login),
+                type: DioExceptionType.connectionError));
+
+        final result = await datasource.login(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '네트워크 연결을 확인해주세요.');
+        verify(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for unexpected error', () async {
+        when(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .thenThrow(Exception('Some unexpected error'));
+
+        final result = await datasource.login(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, contains('예상치 못한 오류가 발생했습니다'));
+        verify(() => mockDio.post(AuthApiPath.login, data: request.toJson()))
+            .called(1);
+      });
+    });
+
+    // --- register tests ---
+    group('register', () {
+      final userAgreement = UserAgreement(
+          isOver14: true,
+          isAgreedToTerms: true,
+          isAgreedToMarketing: false,
+          isConsentedToAds: false);
+      final request = RegisterRequest(
+          userAgreement: userAgreement,
+          email: 'test@test.com',
+          password: 'password',
+          code: '123456');
+      final jwtResponse = {
+        'data': {
+          'accessToken': 'abc',
+          'refreshToken': 'def',
+          'grantType': 'Bearer'
+        }
+      };
+
+      test('should return Success(Jwt) when the call is successful (200 OK)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenAnswer((_) async => Response(
+                requestOptions: RequestOptions(path: AuthApiPath.signup),
+                data: jwtResponse,
+                statusCode: 200));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Success>());
+        expect((result as Success).value, isA<Jwt>());
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) when status code is not 200',
+          () async {
+        final errorResponse = {'message': 'Registration failed'};
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenAnswer((_) async => Response(
+                requestOptions: RequestOptions(path: AuthApiPath.signup),
+                data: errorResponse,
+                statusCode: 400));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for 400 DioException', () async {
+        final errorResponse = {'message': 'Bad request'};
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 400,
+                requestOptions: RequestOptions(path: AuthApiPath.signup),
+                response: Response(
+                    requestOptions: RequestOptions(path: AuthApiPath.signup),
+                    data: errorResponse,
+                    statusCode: 400)));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for other DioException status codes',
+          () async {
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 500,
+                requestOptions: RequestOptions(path: AuthApiPath.signup),
+                response: Response(
+                    requestOptions: RequestOptions(path: AuthApiPath.signup),
+                    data: {},
+                    statusCode: 500)));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '알 수 없는 오류가 발생했습니다.');
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for network error (no response)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenThrow(DioException(
+                requestOptions: RequestOptions(path: AuthApiPath.signup),
+                type: DioExceptionType.connectionError));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '네트워크 연결을 확인해주세요.');
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+
+      test('should return Failure(String) for unexpected error', () async {
+        when(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .thenThrow(Exception('Some unexpected error'));
+
+        final result = await datasource.register(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, contains('예상치 못한 오류가 발생했습니다'));
+        verify(() => mockDio.post(AuthApiPath.signup, data: request.toJson()))
+            .called(1);
+      });
+    });
+
+    // --- sendVerificationEmail tests ---
+    group('sendVerificationEmail', () {
+      final request = EmailVerificationRequest(email: 'test@test.com');
+      final successResponse = {'message': '인증 이메일이 전송되었습니다.'};
+
+      test('should return Success(String) when the call is successful (200 OK)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+                data: request.toJson()))
+            .thenAnswer((_) async => Response(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                data: successResponse,
+                statusCode: 200));
+
+        final result = await datasource.sendVerificationEmail(request);
+
+        expect(result, isA<Success>());
+        expect((result as Success).value, successResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+            data: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) when DioException has message',
+          () async {
+        final errorResponse = {'message': 'Email sending failed'};
+        when(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+                data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 400,
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                response: Response(
+                    requestOptions:
+                        RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                    data: errorResponse,
+                    statusCode: 400)));
+
+        final result = await datasource.sendVerificationEmail(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+            data: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for unknown server response format',
+          () async {
+        when(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+                data: request.toJson()))
+            .thenThrow(DioException.badResponse(
+                statusCode: 400,
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                response: Response(
+                    requestOptions:
+                        RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                    data: 'not a map',
+                    statusCode: 400)));
+
+        final result = await datasource.sendVerificationEmail(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '알 수 없는 서버 응답 형식입니다.');
+        verify(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+            data: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for network error (no response)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+                data: request.toJson()))
+            .thenThrow(DioException(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.sendVerificationEmail),
+                type: DioExceptionType.connectionError));
+
+        final result = await datasource.sendVerificationEmail(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '네트워크 연결을 확인해주세요.');
+        verify(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+            data: request.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for unexpected error', () async {
+        when(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+                data: request.toJson()))
+            .thenThrow(Exception('Some unexpected error'));
+
+        final result = await datasource.sendVerificationEmail(request);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, contains('예상치 못한 오류가 발생했습니다'));
+        verify(() => mockDio.post(AuthApiPath.sendVerificationEmail,
+            data: request.toJson())).called(1);
+      });
+    });
+
+    // --- verifyCode tests ---
+    group('verifyCode', () {
+      const verifyCodeRequest =
+          VerifyCodeRequest(email: 'test@test.com', code: '123456');
+      final successResponse = {'message': '인증에 성공했습니다.'};
+
+      test('should return Success(String) when the call is successful (200 OK)',
+          () async {
+        when(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data:
+                verifyCodeRequest.toJson())).thenAnswer((_) async => Response(
+            requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
+            data: successResponse,
+            statusCode: 200));
+
+        final result = await datasource.verifyCode(verifyCodeRequest);
+
+        expect(result, isA<Success>());
+        expect((result as Success).value, successResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson())).called(1);
+      });
+
+      test('should return Failure(String) when DioException has message',
+          () async {
+        final errorResponse = {'message': 'Invalid code'};
+        when(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data:
+                verifyCodeRequest.toJson())).thenThrow(DioException.badResponse(
+            statusCode: 400,
+            requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
+            response: Response(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkVerifyCode),
+                data: errorResponse,
+                statusCode: 400)));
+
+        final result = await datasource.verifyCode(verifyCodeRequest);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, errorResponse['message']);
+        verify(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for unknown server response format',
+          () async {
+        when(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data:
+                verifyCodeRequest.toJson())).thenThrow(DioException.badResponse(
+            statusCode: 400,
+            requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
+            response: Response(
+                requestOptions:
+                    RequestOptions(path: AuthApiPath.checkVerifyCode),
+                data: 'not a map',
+                statusCode: 400)));
+
+        final result = await datasource.verifyCode(verifyCodeRequest);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '알 수 없는 서버 응답 형식입니다.');
+        verify(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for network error (no response)',
+          () async {
+        when(() =>
+            mockDio.post(AuthApiPath.checkVerifyCode,
+                data: verifyCodeRequest.toJson())).thenThrow(DioException(
+            requestOptions: RequestOptions(path: AuthApiPath.checkVerifyCode),
+            type: DioExceptionType.connectionError));
+
+        final result = await datasource.verifyCode(verifyCodeRequest);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, '네트워크 연결을 확인해주세요.');
+        verify(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson())).called(1);
+      });
+
+      test('should return Failure(String) for unexpected error', () async {
+        when(() => mockDio.post(AuthApiPath.checkVerifyCode,
+                data: verifyCodeRequest.toJson()))
+            .thenThrow(Exception('Some unexpected error'));
+
+        final result = await datasource.verifyCode(verifyCodeRequest);
+
+        expect(result, isA<Failure>());
+        expect((result as Failure).message, contains('예상치 못한 오류가 발생했습니다'));
+        verify(() => mockDio.post(AuthApiPath.checkVerifyCode,
+            data: verifyCodeRequest.toJson())).called(1);
+      });
     });
   });
 }

--- a/test/feature/auth/data/models/check_email_duplicate_test.dart
+++ b/test/feature/auth/data/models/check_email_duplicate_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/check_email_duplicate.dart';
+
+void main() {
+  group(CheckEmailDuplicateRequest, () {
+    const tEmail = 'test@example.com';
+    final tCheckEmailDuplicateRequest =
+        CheckEmailDuplicateRequest(email: tEmail);
+    final tJsonMap = {'email': tEmail};
+
+    test('should be a subclass of CheckEmailDuplicateRequest', () {
+      expect(tCheckEmailDuplicateRequest, isA<CheckEmailDuplicateRequest>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = CheckEmailDuplicateRequest.fromJson(tJsonMap);
+      expect(result, tCheckEmailDuplicateRequest);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tCheckEmailDuplicateRequest.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = CheckEmailDuplicateRequest(email: tEmail);
+      final instance2 = CheckEmailDuplicateRequest(email: tEmail);
+      final instance3 =
+          CheckEmailDuplicateRequest(email: 'another@example.com');
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedEmail = 'updated@example.com';
+      final updatedInstance =
+          tCheckEmailDuplicateRequest.copyWith(email: updatedEmail);
+
+      expect(updatedInstance.email, updatedEmail);
+      expect(updatedInstance, isNot(equals(tCheckEmailDuplicateRequest)));
+    });
+  });
+}

--- a/test/feature/auth/data/models/email_verification_request_test.dart
+++ b/test/feature/auth/data/models/email_verification_request_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/email_verification_request.dart';
+
+void main() {
+  group(EmailVerificationRequest, () {
+    const tEmail = 'test@example.com';
+    final tEmailVerificationRequest = EmailVerificationRequest(email: tEmail);
+    final tJsonMap = {'email': tEmail};
+
+    test('should be a subclass of EmailVerificationRequest', () {
+      expect(tEmailVerificationRequest, isA<EmailVerificationRequest>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = EmailVerificationRequest.fromJson(tJsonMap);
+      expect(result, tEmailVerificationRequest);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tEmailVerificationRequest.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = EmailVerificationRequest(email: tEmail);
+      final instance2 = EmailVerificationRequest(email: tEmail);
+      final instance3 = EmailVerificationRequest(email: 'another@example.com');
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedEmail = 'updated@example.com';
+      final updatedInstance =
+          tEmailVerificationRequest.copyWith(email: updatedEmail);
+
+      expect(updatedInstance.email, updatedEmail);
+      expect(updatedInstance, isNot(equals(tEmailVerificationRequest)));
+    });
+  });
+}

--- a/test/feature/auth/data/models/jwt_test.dart
+++ b/test/feature/auth/data/models/jwt_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/jwt.dart';
+
+void main() {
+  group(Jwt, () {
+    const tGrantType = 'Bearer';
+    const tAccessToken = 'someAccessToken';
+    const tRefreshToken = 'someRefreshToken';
+    final tJwt = Jwt(
+      grantType: tGrantType,
+      accessToken: tAccessToken,
+      refreshToken: tRefreshToken,
+    );
+    final tJsonMap = {
+      'grantType': tGrantType,
+      'accessToken': tAccessToken,
+      'refreshToken': tRefreshToken,
+    };
+
+    test('should be a subclass of Jwt', () {
+      expect(tJwt, isA<Jwt>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = Jwt.fromJson(tJsonMap);
+      expect(result, tJwt);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tJwt.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = Jwt(
+        grantType: tGrantType,
+        accessToken: tAccessToken,
+        refreshToken: tRefreshToken,
+      );
+      final instance2 = Jwt(
+        grantType: tGrantType,
+        accessToken: tAccessToken,
+        refreshToken: tRefreshToken,
+      );
+      final instance3 = Jwt(
+        grantType: 'AnotherType',
+        accessToken: 'anotherAccessToken',
+        refreshToken: 'anotherRefreshToken',
+      );
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedAccessToken = 'updatedAccessToken';
+      final updatedInstance = tJwt.copyWith(accessToken: updatedAccessToken);
+
+      expect(updatedInstance.accessToken, updatedAccessToken);
+      expect(updatedInstance, isNot(equals(tJwt)));
+    });
+  });
+}

--- a/test/feature/auth/data/models/login_test.dart
+++ b/test/feature/auth/data/models/login_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/login.dart';
+
+void main() {
+  group(LoginRequest, () {
+    const tEmail = 'test@example.com';
+    const tPassword = 'password123';
+    final tLoginRequest = LoginRequest(email: tEmail, password: tPassword);
+    final tJsonMap = {'email': tEmail, 'password': tPassword};
+
+    test('should be a subclass of LoginRequest', () {
+      expect(tLoginRequest, isA<LoginRequest>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = LoginRequest.fromJson(tJsonMap);
+      expect(result, tLoginRequest);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tLoginRequest.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = LoginRequest(email: tEmail, password: tPassword);
+      final instance2 = LoginRequest(email: tEmail, password: tPassword);
+      final instance3 = LoginRequest(
+          email: 'another@example.com', password: 'anotherPassword');
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedEmail = 'updated@example.com';
+      final updatedInstance = tLoginRequest.copyWith(email: updatedEmail);
+
+      expect(updatedInstance.email, updatedEmail);
+      expect(updatedInstance, isNot(equals(tLoginRequest)));
+    });
+  });
+}

--- a/test/feature/auth/data/models/register_request_test.dart
+++ b/test/feature/auth/data/models/register_request_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/register_request.dart';
+import 'package:solo_play_application/src/features/auth/data/models/user_agreement.dart';
+
+void main() {
+  group('RegisterRequest', () {
+    const String tEmail = 'test@example.com';
+    const String tPassword = 'password123';
+    const String tCode = '123456';
+
+    final RegisterRequest tRegisterRequest = RegisterRequest(
+        email: tEmail,
+        password: tPassword,
+        code: tCode,
+        userAgreement: UserAgreement(
+            isOver14: true,
+            isAgreedToTerms: true,
+            isAgreedToMarketing: true,
+            isConsentedToAds: true));
+
+    final Map<String, dynamic> tRegisterRequestJson = {
+      'email': tEmail,
+      'password': tPassword,
+      'code': tCode,
+      'userAgreement': {
+        'isOver14': true,
+        'isAgreedToTerms': true,
+        'isAgreedToMarketing': true,
+        'isConsentedToAds': true,
+      }
+    };
+
+    test('should be a subclass of RegisterRequest entity', () {
+      expect(tRegisterRequest, isA<RegisterRequest>());
+    });
+
+    test('should return a valid model from JSON', () {
+      final result = RegisterRequest.fromJson(tRegisterRequestJson);
+      expect(result, tRegisterRequest);
+    });
+
+    test('should return a JSON map containing the proper data', () {
+      final result = tRegisterRequest.toJson();
+      expect(result, tRegisterRequestJson);
+    });
+  });
+}

--- a/test/feature/auth/data/models/user_agreement_test.dart
+++ b/test/feature/auth/data/models/user_agreement_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/user_agreement.dart';
+
+void main() {
+  group('UserAgreement', () {
+    const tIsOver14 = true;
+    const tIsAgreedToTerms = true;
+    const tIsAgreedToMarketing = false;
+    const tIsConsentedToAds = false;
+    final tUserAgreement = UserAgreement(
+      isOver14: tIsOver14,
+      isAgreedToTerms: tIsAgreedToTerms,
+      isAgreedToMarketing: tIsAgreedToMarketing,
+      isConsentedToAds: tIsConsentedToAds,
+    );
+    final tJsonMap = {
+      'isOver14': tIsOver14,
+      'isAgreedToTerms': tIsAgreedToTerms,
+      'isAgreedToMarketing': tIsAgreedToMarketing,
+      'isConsentedToAds': tIsConsentedToAds,
+    };
+
+    test('should be a subclass of UserAgreement', () {
+      expect(tUserAgreement, isA<UserAgreement>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = UserAgreement.fromJson(tJsonMap);
+      expect(result, tUserAgreement);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tUserAgreement.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = UserAgreement(
+        isOver14: tIsOver14,
+        isAgreedToTerms: tIsAgreedToTerms,
+        isAgreedToMarketing: tIsAgreedToMarketing,
+        isConsentedToAds: tIsConsentedToAds,
+      );
+      final instance2 = UserAgreement(
+        isOver14: tIsOver14,
+        isAgreedToTerms: tIsAgreedToTerms,
+        isAgreedToMarketing: tIsAgreedToMarketing,
+        isConsentedToAds: tIsConsentedToAds,
+      );
+      final instance3 = UserAgreement(
+        isOver14: false,
+        isAgreedToTerms: false,
+        isAgreedToMarketing: true,
+        isConsentedToAds: true,
+      );
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedIsAgreedToMarketing = true;
+      final updatedInstance = tUserAgreement.copyWith(isAgreedToMarketing: updatedIsAgreedToMarketing);
+
+      expect(updatedInstance.isAgreedToMarketing, updatedIsAgreedToMarketing);
+      expect(updatedInstance, isNot(equals(tUserAgreement)));
+    });
+  });
+}

--- a/test/feature/auth/data/models/verify_code_request_test.dart
+++ b/test/feature/auth/data/models/verify_code_request_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solo_play_application/src/features/auth/data/models/verify_code_request.dart';
+
+void main() {
+  group('VerifyCodeRequest', () {
+    const tEmail = 'test@example.com';
+    const tCode = '123456';
+    final tVerifyCodeRequest = VerifyCodeRequest(email: tEmail, code: tCode);
+    final tJsonMap = {'email': tEmail, 'code': tCode};
+
+    test('should be a subclass of VerifyCodeRequest', () {
+      expect(tVerifyCodeRequest, isA<VerifyCodeRequest>());
+    });
+
+    test('should correctly parse from JSON', () {
+      final result = VerifyCodeRequest.fromJson(tJsonMap);
+      expect(result, tVerifyCodeRequest);
+    });
+
+    test('should correctly convert to JSON', () {
+      final result = tVerifyCodeRequest.toJson();
+      expect(result, tJsonMap);
+    });
+
+    test('should support value equality', () {
+      final instance1 = VerifyCodeRequest(email: tEmail, code: tCode);
+      final instance2 = VerifyCodeRequest(email: tEmail, code: tCode);
+      final instance3 = VerifyCodeRequest(email: 'another@example.com', code: '654321');
+
+      expect(instance1, equals(instance2));
+      expect(instance1, isNot(equals(instance3)));
+    });
+
+    test('should support copyWith', () {
+      final updatedEmail = 'updated@example.com';
+      final updatedInstance = tVerifyCodeRequest.copyWith(email: updatedEmail);
+
+      expect(updatedInstance.email, updatedEmail);
+      expect(updatedInstance, isNot(equals(tVerifyCodeRequest)));
+    });
+  });
+}


### PR DESCRIPTION
## 작업내용

auth에서 사용하는 외부모델의 단위테스트를 추가했습니다.

이로인해 테스트 커버리지가 100%로 향상했습니다.

## 테스트

<img width="244" height="22" alt="스크린샷 2025-09-23 오후 5 03 11" src="https://github.com/user-attachments/assets/12f13333-9028-4db0-87fc-0f5cb980d98c" />

<img width="1196" height="368" alt="스크린샷 2025-09-23 오후 5 03 42" src="https://github.com/user-attachments/assets/7c30e0e1-00ed-4915-b052-0d487c9380ef" />
