### PR TITLE
Feat: 회원가입 중 이메일 인증 관련 비즈니스 로직과 UI 연결

### DIFF
--- a/lib/src/features/auth/presentation/register/bloc/register_bloc.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:solo_play_application/src/features/auth/domain/entities/user_agreement.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/user_register_usecase.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
 
@@ -9,7 +8,10 @@ import 'register_state.dart';
 class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
   final UserRegisterUsecase _userRegisterUsecase;
 
-  RegisterBloc(this._userRegisterUsecase) : super(const RegisterState()) {
+  RegisterBloc({
+    required UserRegisterUsecase userRegisterUsecase,
+  })  : _userRegisterUsecase = userRegisterUsecase,
+        super(const RegisterState()) {
     on<UpdateTermsAgreement>(_onUpdateTermsAgreement);
     on<UpdateEmail>(_onUpdateEmail);
     on<UpdatePassword>(_onUpdatePassword);
@@ -70,4 +72,3 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     ));
   }
 }
-

--- a/lib/src/features/auth/presentation/register/bloc/register_bloc.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_bloc.dart
@@ -1,14 +1,39 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/user_agreement.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_register_usecase.dart';
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
 
 import 'register_event.dart';
 import 'register_state.dart';
 
 class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
-  RegisterBloc() : super(const RegisterState()) {
+  final UserRegisterUsecase _userRegisterUsecase;
+
+  RegisterBloc(this._userRegisterUsecase) : super(const RegisterState()) {
     on<UpdateTermsAgreement>(_onUpdateTermsAgreement);
     on<UpdateEmail>(_onUpdateEmail);
     on<UpdatePassword>(_onUpdatePassword);
+    on<RegisterSubmitted>(_onRegisterSubmitted);
+  }
+
+  void _onRegisterSubmitted(
+    RegisterSubmitted event,
+    Emitter<RegisterState> emit,
+  ) async {
+    emit(state.copyWith(status: RegisterStatus.loading));
+    final result = await _userRegisterUsecase.call(state.register);
+
+    switch (result) {
+      case Success():
+        emit(state.copyWith(status: RegisterStatus.success));
+        break;
+      case Failure(message: final message):
+        emit(state.copyWith(
+          status: RegisterStatus.error,
+          errorMessage: message,
+        ));
+        break;
+    }
   }
 
   void _onUpdateTermsAgreement(

--- a/lib/src/features/auth/presentation/register/bloc/register_event.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_event.dart
@@ -14,4 +14,8 @@ sealed class RegisterEvent with _$RegisterEvent {
   const factory RegisterEvent.updatePassword({
     required String password,
   }) = UpdatePassword;
+  const factory RegisterEvent.registerSubmitted({
+    required String email,
+    required String password,
+  }) = RegisterSubmitted;
 }

--- a/lib/src/features/auth/presentation/register/bloc/register_event.freezed.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_event.freezed.dart
@@ -241,4 +241,76 @@ class _$UpdatePasswordCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
+
+class RegisterSubmitted implements RegisterEvent {
+  const RegisterSubmitted({required this.email, required this.password});
+
+  final String email;
+  final String password;
+
+  /// Create a copy of RegisterEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $RegisterSubmittedCopyWith<RegisterSubmitted> get copyWith =>
+      _$RegisterSubmittedCopyWithImpl<RegisterSubmitted>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is RegisterSubmitted &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, email, password);
+
+  @override
+  String toString() {
+    return 'RegisterEvent.registerSubmitted(email: $email, password: $password)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RegisterSubmittedCopyWith<$Res>
+    implements $RegisterEventCopyWith<$Res> {
+  factory $RegisterSubmittedCopyWith(
+          RegisterSubmitted value, $Res Function(RegisterSubmitted) _then) =
+      _$RegisterSubmittedCopyWithImpl;
+  @useResult
+  $Res call({String email, String password});
+}
+
+/// @nodoc
+class _$RegisterSubmittedCopyWithImpl<$Res>
+    implements $RegisterSubmittedCopyWith<$Res> {
+  _$RegisterSubmittedCopyWithImpl(this._self, this._then);
+
+  final RegisterSubmitted _self;
+  final $Res Function(RegisterSubmitted) _then;
+
+  /// Create a copy of RegisterEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+  }) {
+    return _then(RegisterSubmitted(
+      email: null == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
 // dart format on

--- a/lib/src/features/auth/presentation/register/bloc/register_state.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_state.dart
@@ -4,11 +4,14 @@ import 'package:solo_play_application/src/features/auth/domain/entities/register
 part 'register_state.freezed.dart';
 
 enum RegisterStep { terms, email, password }
+enum RegisterStatus { initial, loading, success, error }
 
 @freezed
 abstract class RegisterState with _$RegisterState {
   const factory RegisterState({
     @Default(RegisterStep.terms) RegisterStep step,
     @Default(Register()) Register register,
+    @Default(RegisterStatus.initial) RegisterStatus status,
+    String? errorMessage,
   }) = _RegisterState;
 }

--- a/lib/src/features/auth/presentation/register/bloc/register_state.freezed.dart
+++ b/lib/src/features/auth/presentation/register/bloc/register_state.freezed.dart
@@ -17,6 +17,8 @@ T _$identity<T>(T value) => value;
 mixin _$RegisterState {
   RegisterStep get step;
   Register get register;
+  RegisterStatus get status;
+  String? get errorMessage;
 
   /// Create a copy of RegisterState
   /// with the given fields replaced by the non-null parameter values.
@@ -33,15 +35,19 @@ mixin _$RegisterState {
             other is RegisterState &&
             (identical(other.step, step) || other.step == step) &&
             (identical(other.register, register) ||
-                other.register == register));
+                other.register == register) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, step, register);
+  int get hashCode =>
+      Object.hash(runtimeType, step, register, status, errorMessage);
 
   @override
   String toString() {
-    return 'RegisterState(step: $step, register: $register)';
+    return 'RegisterState(step: $step, register: $register, status: $status, errorMessage: $errorMessage)';
   }
 }
 
@@ -51,7 +57,11 @@ abstract mixin class $RegisterStateCopyWith<$Res> {
           RegisterState value, $Res Function(RegisterState) _then) =
       _$RegisterStateCopyWithImpl;
   @useResult
-  $Res call({RegisterStep step, Register register});
+  $Res call(
+      {RegisterStep step,
+      Register register,
+      RegisterStatus status,
+      String? errorMessage});
 
   $RegisterCopyWith<$Res> get register;
 }
@@ -71,6 +81,8 @@ class _$RegisterStateCopyWithImpl<$Res>
   $Res call({
     Object? step = null,
     Object? register = null,
+    Object? status = null,
+    Object? errorMessage = freezed,
   }) {
     return _then(_self.copyWith(
       step: null == step
@@ -81,6 +93,14 @@ class _$RegisterStateCopyWithImpl<$Res>
           ? _self.register
           : register // ignore: cast_nullable_to_non_nullable
               as Register,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as RegisterStatus,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 
@@ -99,7 +119,10 @@ class _$RegisterStateCopyWithImpl<$Res>
 
 class _RegisterState implements RegisterState {
   const _RegisterState(
-      {this.step = RegisterStep.terms, this.register = const Register()});
+      {this.step = RegisterStep.terms,
+      this.register = const Register(),
+      this.status = RegisterStatus.initial,
+      this.errorMessage});
 
   @override
   @JsonKey()
@@ -107,6 +130,11 @@ class _RegisterState implements RegisterState {
   @override
   @JsonKey()
   final Register register;
+  @override
+  @JsonKey()
+  final RegisterStatus status;
+  @override
+  final String? errorMessage;
 
   /// Create a copy of RegisterState
   /// with the given fields replaced by the non-null parameter values.
@@ -123,15 +151,19 @@ class _RegisterState implements RegisterState {
             other is _RegisterState &&
             (identical(other.step, step) || other.step == step) &&
             (identical(other.register, register) ||
-                other.register == register));
+                other.register == register) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, step, register);
+  int get hashCode =>
+      Object.hash(runtimeType, step, register, status, errorMessage);
 
   @override
   String toString() {
-    return 'RegisterState(step: $step, register: $register)';
+    return 'RegisterState(step: $step, register: $register, status: $status, errorMessage: $errorMessage)';
   }
 }
 
@@ -143,7 +175,11 @@ abstract mixin class _$RegisterStateCopyWith<$Res>
       __$RegisterStateCopyWithImpl;
   @override
   @useResult
-  $Res call({RegisterStep step, Register register});
+  $Res call(
+      {RegisterStep step,
+      Register register,
+      RegisterStatus status,
+      String? errorMessage});
 
   @override
   $RegisterCopyWith<$Res> get register;
@@ -164,6 +200,8 @@ class __$RegisterStateCopyWithImpl<$Res>
   $Res call({
     Object? step = null,
     Object? register = null,
+    Object? status = null,
+    Object? errorMessage = freezed,
   }) {
     return _then(_RegisterState(
       step: null == step
@@ -174,6 +212,14 @@ class __$RegisterStateCopyWithImpl<$Res>
           ? _self.register
           : register // ignore: cast_nullable_to_non_nullable
               as Register,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as RegisterStatus,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 

--- a/lib/src/features/auth/presentation/register/pages/register_flow.dart
+++ b/lib/src/features/auth/presentation/register/pages/register_flow.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_register_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
 
 class RegisterFlow extends StatelessWidget {
@@ -8,8 +10,17 @@ class RegisterFlow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<RegisterBloc>(
-      create: (context) => RegisterBloc(),
+    return MultiBlocProvider(
+      providers: [
+        RepositoryProvider<UserRegisterUsecase>(
+          create: (context) => UserRegisterUsecaseImpl(
+              authRepository: context.read<AuthRepository>()),
+        ),
+        BlocProvider<RegisterBloc>(
+          create: (context) => RegisterBloc(
+              userRegisterUsecase: context.read<UserRegisterUsecase>()),
+        ),
+      ],
       child: PopScope(
         onPopInvokedWithResult: (didPop, result) {},
         child: GestureDetector(

--- a/lib/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart
+++ b/lib/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart
@@ -5,6 +5,8 @@ import 'package:go_router/go_router.dart';
 import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
@@ -14,39 +16,59 @@ class VerificationConfirmButtonSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocConsumer<VerificationBloc, VerificationState>(
-      listener: (context, state) {
-        if (state.status == VerificationStatus.verified) {
-          log('Verification successful. Navigating to RegisterCompleteUI.');
-          context.push(RouterPath.verificationComplete);
-        } else if (state.status == VerificationStatus.error) {
-          log('Error verifying code: ${state.errorMessage}');
-        }
-      },
-      builder: (context, state) {
-        final bool isButtonEnabled = state.code.length == 6;
-        return PrimaryButton(
-          onTap: isButtonEnabled
-              ? () {
-                  final email = context.read<RegisterBloc>().state.register.email;
-                  final code = state.code;
-                  context.read<VerificationBloc>().add(
-                        VerificationEvent.verificationSubmitted(email, code),
-                      );
-                }
-              : null,
-          child: Text(
-            '다음',
-            style: TextStyle(
-              color: isButtonEnabled
-                  ? const Color(0xffffffff)
-                  : const Color(0xff8e8e8e),
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<VerificationBloc, VerificationState>(
+          listener: (context, state) {
+            if (state.status == VerificationStatus.verified) {
+              log('Verification successful. Triggering user registration.');
+              final email = context.read<RegisterBloc>().state.register.email;
+              final password = context.read<RegisterBloc>().state.register.password;
+              context.read<RegisterBloc>().add(
+                    RegisterEvent.registerSubmitted(email: email, password: password),
+                  );
+            } else if (state.status == VerificationStatus.error) {
+              log('Error verifying code: ${state.errorMessage}');
+            }
+          },
+        ),
+        BlocListener<RegisterBloc, RegisterState>(
+          listener: (context, state) {
+            if (state.status == RegisterStatus.success) {
+              log('User registration successful. Navigating to RegisterCompleteUI.');
+              context.push(RouterPath.verificationComplete);
+            } else if (state.status == RegisterStatus.error) {
+              log('Error during user registration: ${state.errorMessage}');
+            }
+          },
+        ),
+      ],
+      child: BlocBuilder<VerificationBloc, VerificationState>(
+        builder: (context, state) {
+          final bool isButtonEnabled = state.code.length == 6;
+          return PrimaryButton(
+            onTap: isButtonEnabled
+                ? () {
+                    final email = context.read<RegisterBloc>().state.register.email;
+                    final code = state.code;
+                    context.read<VerificationBloc>().add(
+                          VerificationEvent.verificationSubmitted(email, code),
+                        );
+                  }
+                : null,
+            child: Text(
+              '다음',
+              style: TextStyle(
+                color: isButtonEnabled
+                    ? const Color(0xffffffff)
+                    : const Color(0xff8e8e8e),
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart
+++ b/lib/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart
@@ -1,23 +1,38 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart'; // Import Bloc
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 
 class VerificationConfirmButtonSection extends StatelessWidget {
-  const VerificationConfirmButtonSection({super.key}); // Corrected constructor
+  const VerificationConfirmButtonSection({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<VerificationBloc, VerificationState>(
+    return BlocConsumer<VerificationBloc, VerificationState>(
+      listener: (context, state) {
+        if (state.status == VerificationStatus.verified) {
+          log('Verification successful. Navigating to RegisterCompleteUI.');
+          context.push(RouterPath.verificationComplete);
+        } else if (state.status == VerificationStatus.error) {
+          log('Error verifying code: ${state.errorMessage}');
+        }
+      },
       builder: (context, state) {
         final bool isButtonEnabled = state.code.length == 6;
         return PrimaryButton(
           onTap: isButtonEnabled
               ? () {
-                  context.push(RouterPath.verificationComplete);
+                  final email = context.read<RegisterBloc>().state.register.email;
+                  final code = state.code;
+                  context.read<VerificationBloc>().add(
+                        VerificationEvent.verificationSubmitted(email, code),
+                      );
                 }
               : null,
           child: Text(

--- a/lib/src/features/auth/presentation/verification/sections/verification_intro_button_section.dart
+++ b/lib/src/features/auth/presentation/verification/sections/verification_intro_button_section.dart
@@ -1,23 +1,43 @@
+import 'dart:developer';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 
 class VerificationIntroButtonSection extends StatelessWidget {
   const VerificationIntroButtonSection({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return PrimaryButton(
-      onTap: () {
-        context.push(RouterPath.verficationEmail);
+    return BlocListener<VerificationBloc, VerificationState>(
+      listener: (context, state) {
+        if (state.status == VerificationStatus.sent) {
+          log('Verification email sent successfully. Navigating to VerificationEmailPage.');
+          context.push(RouterPath.verficationEmail);
+        } else if (state.status == VerificationStatus.error) {
+          log('Error sending verification email: ${state.errorMessage}');
+        }
       },
-      activeChild: Text(
-        '본인인증 하러 가기',
-        style: TextStyle(
-            color: Color(0xffffffff),
-            fontWeight: FontWeight.w700,
-            fontSize: 16),
+      child: PrimaryButton(
+        onTap: () {
+          final email = context.read<RegisterBloc>().state.register.email;
+          context.read<VerificationBloc>().add(
+                VerificationEvent.verificationEmailSent(email),
+              );
+        },
+        activeChild: const Text(
+          '본인인증 하러 가기',
+          style: TextStyle(
+              color: Color(0xffffffff),
+              fontWeight: FontWeight.w700,
+              fontSize: 16),
+        ),
       ),
     );
   }

--- a/test/core/mocks/mocks.dart
+++ b/test/core/mocks/mocks.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:solo_play_application/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:solo_play_application/src/features/auth/domain/usecases/user_login_usecase.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_register_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/bloc/bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/login/bloc/bloc.dart';
 
@@ -11,5 +12,7 @@ class MockLoginBloc extends MockBloc<LoginEvent, LoginState>
     implements LoginBloc {}
 
 class MockUserLoginUsecase extends Mock implements UserLoginUsecase {}
+
+class MockUserRegisterUsecase extends Mock implements UserRegisterUsecase {}
 
 class MockAuthRepository extends Mock implements AuthRepository {}

--- a/test/feature/auth/presentation/register/bloc/register_bloc_test.dart
+++ b/test/feature/auth/presentation/register/bloc/register_bloc_test.dart
@@ -32,8 +32,9 @@ void main() {
 
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated terms agreement when UpdateTermsAgreement is added.',
-      build: () => RegisterBloc(mockUserRegisterUsecase),
-      act: (bloc) => bloc.add(const UpdateTermsAgreement(userAgreement: userAgreement)),
+      build: () => RegisterBloc(userRegisterUsecase: mockUserRegisterUsecase),
+      act: (bloc) =>
+          bloc.add(const UpdateTermsAgreement(userAgreement: userAgreement)),
       expect: () => [
         const RegisterState(
           register: Register(
@@ -46,7 +47,7 @@ void main() {
 
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated email when UpdateEmail is added.',
-      build: () => RegisterBloc(mockUserRegisterUsecase),
+      build: () => RegisterBloc(userRegisterUsecase: mockUserRegisterUsecase),
       act: (bloc) => bloc.add(const UpdateEmail(email: 'test@example.com')),
       expect: () => [
         const RegisterState(
@@ -57,7 +58,7 @@ void main() {
 
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated password when UpdatePassword is added.',
-      build: () => RegisterBloc(mockUserRegisterUsecase),
+      build: () => RegisterBloc(userRegisterUsecase: mockUserRegisterUsecase),
       act: (bloc) => bloc.add(const UpdatePassword(password: 'password')),
       expect: () => [
         const RegisterState(
@@ -71,16 +72,19 @@ void main() {
       build: () {
         when(() => mockUserRegisterUsecase.call(any()))
             .thenAnswer((_) async => const Result.success(null));
-        return RegisterBloc(mockUserRegisterUsecase);
+        return RegisterBloc(userRegisterUsecase: mockUserRegisterUsecase);
       },
       act: (bloc) {
         bloc.add(const UpdateEmail(email: 'test@example.com'));
         bloc.add(const UpdatePassword(password: 'password'));
-        bloc.add(const RegisterSubmitted(email: 'test@example.com', password: 'password'));
+        bloc.add(const RegisterSubmitted(
+            email: 'test@example.com', password: 'password'));
       },
       expect: () => [
         const RegisterState(register: Register(email: 'test@example.com')),
-        const RegisterState(register: Register(email: 'test@example.com', password: 'password')),
+        const RegisterState(
+            register:
+                Register(email: 'test@example.com', password: 'password')),
         const RegisterState(
           register: Register(email: 'test@example.com', password: 'password'),
           status: RegisterStatus.loading,
@@ -100,18 +104,21 @@ void main() {
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterStatus.loading, RegisterStatus.error] when RegisterSubmitted is added and registration fails.',
       build: () {
-        when(() => mockUserRegisterUsecase.call(any()))
-            .thenAnswer((_) async => const Result.failure('Registration failed'));
-        return RegisterBloc(mockUserRegisterUsecase);
+        when(() => mockUserRegisterUsecase.call(any())).thenAnswer(
+            (_) async => const Result.failure('Registration failed'));
+        return RegisterBloc(userRegisterUsecase: mockUserRegisterUsecase);
       },
       act: (bloc) {
         bloc.add(const UpdateEmail(email: 'test@example.com'));
         bloc.add(const UpdatePassword(password: 'password'));
-        bloc.add(const RegisterSubmitted(email: 'test@example.com', password: 'password'));
+        bloc.add(const RegisterSubmitted(
+            email: 'test@example.com', password: 'password'));
       },
       expect: () => [
         const RegisterState(register: Register(email: 'test@example.com')),
-        const RegisterState(register: Register(email: 'test@example.com', password: 'password')),
+        const RegisterState(
+            register:
+                Register(email: 'test@example.com', password: 'password')),
         const RegisterState(
           register: Register(email: 'test@example.com', password: 'password'),
           status: RegisterStatus.loading,

--- a/test/feature/auth/presentation/register/bloc/register_bloc_test.dart
+++ b/test/feature/auth/presentation/register/bloc/register_bloc_test.dart
@@ -1,13 +1,24 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/core/utils/networks/result.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/register.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/user_agreement.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_register_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
 
+class MockUserRegisterUsecase extends Mock implements UserRegisterUsecase {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const Register());
+  });
+
   group('RegisterBloc', () {
+    late MockUserRegisterUsecase mockUserRegisterUsecase;
+
     const userAgreement = UserAgreement(
       isOver14: true,
       isAgreedToTerms: true,
@@ -15,9 +26,13 @@ void main() {
       isConsentedToAds: false,
     );
 
+    setUp(() {
+      mockUserRegisterUsecase = MockUserRegisterUsecase();
+    });
+
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated terms agreement when UpdateTermsAgreement is added.',
-      build: () => RegisterBloc(),
+      build: () => RegisterBloc(mockUserRegisterUsecase),
       act: (bloc) => bloc.add(const UpdateTermsAgreement(userAgreement: userAgreement)),
       expect: () => [
         const RegisterState(
@@ -31,7 +46,7 @@ void main() {
 
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated email when UpdateEmail is added.',
-      build: () => RegisterBloc(),
+      build: () => RegisterBloc(mockUserRegisterUsecase),
       act: (bloc) => bloc.add(const UpdateEmail(email: 'test@example.com')),
       expect: () => [
         const RegisterState(
@@ -42,13 +57,76 @@ void main() {
 
     blocTest<RegisterBloc, RegisterState>(
       'emits [RegisterState] with updated password when UpdatePassword is added.',
-      build: () => RegisterBloc(),
+      build: () => RegisterBloc(mockUserRegisterUsecase),
       act: (bloc) => bloc.add(const UpdatePassword(password: 'password')),
       expect: () => [
         const RegisterState(
           register: Register(password: 'password'),
         ),
       ],
+    );
+
+    blocTest<RegisterBloc, RegisterState>(
+      'emits [RegisterStatus.loading, RegisterStatus.success] when RegisterSubmitted is added and registration is successful.',
+      build: () {
+        when(() => mockUserRegisterUsecase.call(any()))
+            .thenAnswer((_) async => const Result.success(null));
+        return RegisterBloc(mockUserRegisterUsecase);
+      },
+      act: (bloc) {
+        bloc.add(const UpdateEmail(email: 'test@example.com'));
+        bloc.add(const UpdatePassword(password: 'password'));
+        bloc.add(const RegisterSubmitted(email: 'test@example.com', password: 'password'));
+      },
+      expect: () => [
+        const RegisterState(register: Register(email: 'test@example.com')),
+        const RegisterState(register: Register(email: 'test@example.com', password: 'password')),
+        const RegisterState(
+          register: Register(email: 'test@example.com', password: 'password'),
+          status: RegisterStatus.loading,
+        ),
+        const RegisterState(
+          register: Register(email: 'test@example.com', password: 'password'),
+          status: RegisterStatus.success,
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockUserRegisterUsecase.call(
+              const Register(email: 'test@example.com', password: 'password'),
+            )).called(1);
+      },
+    );
+
+    blocTest<RegisterBloc, RegisterState>(
+      'emits [RegisterStatus.loading, RegisterStatus.error] when RegisterSubmitted is added and registration fails.',
+      build: () {
+        when(() => mockUserRegisterUsecase.call(any()))
+            .thenAnswer((_) async => const Result.failure('Registration failed'));
+        return RegisterBloc(mockUserRegisterUsecase);
+      },
+      act: (bloc) {
+        bloc.add(const UpdateEmail(email: 'test@example.com'));
+        bloc.add(const UpdatePassword(password: 'password'));
+        bloc.add(const RegisterSubmitted(email: 'test@example.com', password: 'password'));
+      },
+      expect: () => [
+        const RegisterState(register: Register(email: 'test@example.com')),
+        const RegisterState(register: Register(email: 'test@example.com', password: 'password')),
+        const RegisterState(
+          register: Register(email: 'test@example.com', password: 'password'),
+          status: RegisterStatus.loading,
+        ),
+        const RegisterState(
+          register: Register(email: 'test@example.com', password: 'password'),
+          status: RegisterStatus.error,
+          errorMessage: 'Registration failed',
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockUserRegisterUsecase.call(
+              const Register(email: 'test@example.com', password: 'password'),
+            )).called(1);
+      },
     );
   });
 }

--- a/test/feature/auth/presentation/verification/bloc/verification_bloc_test.dart
+++ b/test/feature/auth/presentation/verification/bloc/verification_bloc_test.dart
@@ -2,16 +2,12 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:solo_play_application/src/core/utils/networks/result.dart';
-import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
-import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 
-class MockSendVerificationEmailUsecase extends Mock
-    implements SendVerificationEmailUsecase {}
-
-class MockUserVerifyCodeUsecase extends Mock implements UserVerifyCodeUsecase {}
+import '../mocks/mock_send_verification_email_usecase.dart';
+import '../mocks/mock_user_verify_code_usecase.dart';
 
 void main() {
   group(VerificationBloc, () {

--- a/test/feature/auth/presentation/verification/mocks/mock_go_router.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_go_router.dart
@@ -1,0 +1,4 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:go_router/go_router.dart';
+
+class MockGoRouter extends Mock implements GoRouter {}

--- a/test/feature/auth/presentation/verification/mocks/mock_register_bloc.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_register_bloc.dart
@@ -1,0 +1,7 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
+
+class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
+    implements RegisterBloc {}

--- a/test/feature/auth/presentation/verification/mocks/mock_send_verification_email_usecase.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_send_verification_email_usecase.dart
@@ -1,0 +1,5 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/send_verification_email_usecase.dart';
+
+class MockSendVerificationEmailUsecase extends Mock
+    implements SendVerificationEmailUsecase {}

--- a/test/feature/auth/presentation/verification/mocks/mock_timer_bloc.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_timer_bloc.dart
@@ -1,0 +1,7 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:solo_play_application/src/features/timer/bloc/timer_bloc.dart';
+import 'package:solo_play_application/src/features/timer/bloc/timer_event.dart';
+import 'package:solo_play_application/src/features/timer/bloc/timer_state.dart';
+
+class MockTimerBloc extends MockBloc<TimerEvent, TimerState>
+    implements TimerBloc {}

--- a/test/feature/auth/presentation/verification/mocks/mock_user_verify_code_usecase.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_user_verify_code_usecase.dart
@@ -1,0 +1,4 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/features/auth/domain/usecases/user_verify_code_usecase.dart';
+
+class MockUserVerifyCodeUsecase extends Mock implements UserVerifyCodeUsecase {}

--- a/test/feature/auth/presentation/verification/mocks/mock_verification_bloc.dart
+++ b/test/feature/auth/presentation/verification/mocks/mock_verification_bloc.dart
@@ -1,0 +1,8 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
+
+class MockVerificationBloc
+    extends MockBloc<VerificationEvent, VerificationState>
+    implements VerificationBloc {}

--- a/test/feature/auth/presentation/verification/sections/verification_code_input_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_code_input_section_test.dart
@@ -10,15 +10,11 @@ import 'package:solo_play_application/src/features/auth/presentation/verificatio
 import 'package:solo_play_application/src/core/widgets/primary_text_field.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_code_input_section.dart';
 import 'package:solo_play_application/src/features/timer/bloc/timer_bloc.dart';
-import 'package:solo_play_application/src/features/timer/bloc/timer_event.dart';
 import 'package:solo_play_application/src/features/timer/bloc/timer_state.dart';
 import 'package:solo_play_application/src/features/timer/presentation/views/timer_view.dart'; // Import TimerState
 
-class MockTimerBloc extends MockBloc<TimerEvent, TimerState>
-    implements TimerBloc {}
-
-class MockVerificationBloc extends MockBloc<VerificationEvent, VerificationState>
-    implements VerificationBloc {}
+import '../mocks/mock_timer_bloc.dart';
+import '../mocks/mock_verification_bloc.dart';
 
 void main() {
   group(VerificationCodeInputSection, () {
@@ -32,7 +28,8 @@ void main() {
 
     testWidgets('should render text and PrimaryTextField correctly',
         (WidgetTester tester) async {
-      whenListen(mockVerificationBloc, Stream.fromIterable([const VerificationState()]),
+      whenListen(mockVerificationBloc,
+          Stream.fromIterable([const VerificationState()]),
           initialState: const VerificationState()); // Initial state for Cubit
       whenListen(mockTimerBloc, Stream.fromIterable([const TimerInitial(600)]),
           initialState: const TimerInitial(600)); // Initial state for TimerBloc
@@ -79,7 +76,8 @@ void main() {
       expect(textFieldFinder, findsOneWidget);
       final primaryTextField = tester.widget<PrimaryTextField>(textFieldFinder);
       expect(primaryTextField.hintText, '123456');
-      expect(primaryTextField.keyboardType, const TextInputType.numberWithOptions());
+      expect(primaryTextField.keyboardType,
+          const TextInputType.numberWithOptions());
 
       // Check for SizedBox between text field and timer
       final sizedBox2 = column.children[3] as SizedBox;
@@ -91,7 +89,9 @@ void main() {
       // Simulate text input and verify Cubit update
       await tester.enterText(textFieldFinder, '123');
       await tester.pump();
-      verify(() => mockVerificationBloc.add(const VerificationCodeChanged('123'))).called(1);
+      verify(() =>
+              mockVerificationBloc.add(const VerificationCodeChanged('123')))
+          .called(1);
 
       // Golden test
       await expectLater(
@@ -103,7 +103,8 @@ void main() {
     testWidgets('should unfocus when code length reaches 6',
         (WidgetTester tester) async {
       // Arrange
-      whenListen(mockVerificationBloc, Stream.fromIterable([const VerificationState()]),
+      whenListen(mockVerificationBloc,
+          Stream.fromIterable([const VerificationState()]),
           initialState: const VerificationState());
       whenListen(mockTimerBloc, Stream.fromIterable([const TimerInitial(600)]),
           initialState: const TimerInitial(600));
@@ -143,7 +144,9 @@ void main() {
       await tester.pump();
 
       // Assert: Cubit is updated
-      verify(() => mockVerificationBloc.add(const VerificationCodeChanged('123456'))).called(1);
+      verify(() =>
+              mockVerificationBloc.add(const VerificationCodeChanged('123456')))
+          .called(1);
 
       // Assert: The text field should have lost focus
       expect(focusNode?.hasFocus, isFalse);

--- a/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
@@ -35,12 +35,15 @@ void main() {
       registerFallbackValue(VerificationEvent.verificationSubmitted('', ''));
       registerFallbackValue(RegisterState());
       registerFallbackValue(Uri.parse('/'));
+      registerFallbackValue(RegisterEvent.registerSubmitted(email: '', password: ''));
     });
 
     setUp(() {
       mockVerificationBloc = MockVerificationBloc();
       mockRegisterBloc = MockRegisterBloc();
       mockGoRouter = MockGoRouter();
+      when(() => mockRegisterBloc.add(any())).thenReturn(null);
+      when(() => mockRegisterBloc.state).thenReturn(const RegisterState());
     });
 
     testWidgets('displays disabled button when input is less than 6 characters',
@@ -53,8 +56,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BlocProvider<VerificationBloc>.value(
-              value: mockVerificationBloc,
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+                BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+              ],
               child: const VerificationConfirmButtonSection(),
             ),
           ),
@@ -97,8 +103,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BlocProvider<VerificationBloc>.value(
-              value: mockVerificationBloc,
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+                BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+              ],
               child: const VerificationConfirmButtonSection(),
             ),
           ),
@@ -137,22 +146,24 @@ void main() {
       // Arrange
       const testEmail = 'test@example.com';
       const testCode = '123456';
+      const testPassword = 'password';
 
       when(() => mockVerificationBloc.state)
           .thenReturn(const VerificationState(code: testCode));
       when(() => mockRegisterBloc.state)
-          .thenReturn(RegisterState(register: Register(email: testEmail)));
+          .thenReturn(RegisterState(register: Register(email: testEmail, password: testPassword)));
       when(() => mockVerificationBloc.add(any())).thenReturn(null);
+      // when(() => mockRegisterBloc.add(any())).thenReturn(null); // setUp에서 처리
 
       await tester.pumpWidget(
         MaterialApp(
-          home: BlocProvider<RegisterBloc>.value(
-            value: mockRegisterBloc,
-            child: BlocProvider<VerificationBloc>.value(
-              value: mockVerificationBloc,
-              child: const Scaffold(
-                body: VerificationConfirmButtonSection(),
-              ),
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+              BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+            ],
+            child: const Scaffold(
+              body: VerificationConfirmButtonSection(),
             ),
           ),
         ),
@@ -167,43 +178,70 @@ void main() {
       verify(() => mockVerificationBloc.add(
               VerificationEvent.verificationSubmitted(testEmail, testCode)))
           .called(1);
+      // verify(() => mockRegisterBloc.add(any(that: isA<RegisterSubmitted>()))) // 이 라인 제거
+      //     .called(1);
     });
 
-    testWidgets('navigates to verificationComplete when status is verified',
+    testWidgets('navigates to verificationComplete when verification and registration are successful',
         (WidgetTester tester) async {
       // Arrange
+      const testEmail = 'test@example.com';
+      const testPassword = 'password';
+
+      // VerificationBloc이 verified 상태를 방출하도록 설정
       whenListen(
         mockVerificationBloc,
         Stream.fromIterable([
-          const VerificationState(status: VerificationStatus.verified),
+          const VerificationState(status: VerificationStatus.verified, code: '123456'),
         ]),
-        initialState: const VerificationState(),
+        initialState: const VerificationState(code: '123456'),
       );
+
+      // RegisterBloc의 초기 상태 설정
       when(() => mockRegisterBloc.state).thenReturn(
-          const RegisterState(register: Register(email: 'test@example.com')));
+          RegisterState(register: Register(email: testEmail, password: testPassword)));
+
+      // RegisterBloc이 RegisterSubmitted 이벤트를 받았을 때 success 상태를 방출하도록 설정
+      whenListen(
+        mockRegisterBloc,
+        Stream.fromIterable([
+          RegisterState(
+            register: Register(email: testEmail, password: testPassword),
+            status: RegisterStatus.loading,
+          ),
+          RegisterState(
+            register: Register(email: testEmail, password: testPassword),
+            status: RegisterStatus.success,
+          ),
+        ]),
+        initialState: RegisterState(register: Register(email: testEmail, password: testPassword)),
+      );
+
       when(() => mockGoRouter.push(any())).thenAnswer((_) async => '');
 
       await tester.pumpWidget(
         MaterialApp(
-          home: BlocProvider<RegisterBloc>.value(
-            value: mockRegisterBloc,
-            child: BlocProvider<VerificationBloc>.value(
-              value: mockVerificationBloc,
-              child: InheritedGoRouter(
-                goRouter: mockGoRouter,
-                child: const Scaffold(
-                  body: VerificationConfirmButtonSection(),
-                ),
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+              BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+            ],
+            child: InheritedGoRouter(
+              goRouter: mockGoRouter,
+              child: const Scaffold(
+                body: VerificationConfirmButtonSection(),
               ),
             ),
           ),
         ),
       );
 
-      // Act - No direct interaction needed, just pump to trigger listener
+      // Act - VerificationBloc의 verified 상태가 트리거되고, RegisterBloc의 success 상태가 트리거될 때까지 기다림
       await tester.pumpAndSettle();
 
       // Assert
+      verify(() => mockRegisterBloc.add(any(that: isA<RegisterSubmitted>()))) // 추가된 부분
+          .called(1);
       verify(() => mockGoRouter.push(RouterPath.verificationComplete))
           .called(1);
     });
@@ -229,15 +267,15 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: BlocProvider<RegisterBloc>.value(
-            value: mockRegisterBloc,
-            child: BlocProvider<VerificationBloc>.value(
-              value: mockVerificationBloc,
-              child: InheritedGoRouter(
-                goRouter: mockGoRouter,
-                child: const Scaffold(
-                  body: VerificationConfirmButtonSection(),
-                ),
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+              BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+            ],
+            child: InheritedGoRouter(
+              goRouter: mockGoRouter,
+              child: const Scaffold(
+                body: VerificationConfirmButtonSection(),
               ),
             ),
           ),

--- a/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
@@ -2,28 +2,50 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:go_router/go_router.dart';
+import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/register.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart';
 
-// Mock Bloc for testing
+// Mock Blocs for testing
 class MockVerificationBloc
     extends MockBloc<VerificationEvent, VerificationState>
     implements VerificationBloc {}
 
+class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
+    implements RegisterBloc {}
+
+class MockGoRouter extends Mock implements GoRouter {}
+
 void main() {
-  group('VerificationConfirmButtonSection', () {
-    late MockVerificationBloc mockBloc;
+  group(VerificationConfirmButtonSection, () {
+    late MockVerificationBloc mockVerificationBloc;
+    late MockRegisterBloc mockRegisterBloc;
+    late MockGoRouter mockGoRouter;
+
+    setUpAll(() {
+      registerFallbackValue(VerificationEvent.verificationSubmitted('', ''));
+      registerFallbackValue(RegisterState());
+      registerFallbackValue(Uri.parse('/'));
+    });
 
     setUp(() {
-      mockBloc = MockVerificationBloc();
+      mockVerificationBloc = MockVerificationBloc();
+      mockRegisterBloc = MockRegisterBloc();
+      mockGoRouter = MockGoRouter();
     });
 
     testWidgets('displays disabled button when input is less than 6 characters',
         (WidgetTester tester) async {
-      whenListen(mockBloc,
+      whenListen(mockVerificationBloc,
           Stream.fromIterable([const VerificationState(code: '12345')]),
           initialState:
               const VerificationState(code: '12345')); // Simulate code input
@@ -32,7 +54,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: BlocProvider<VerificationBloc>.value(
-              value: mockBloc,
+              value: mockVerificationBloc,
               child: const VerificationConfirmButtonSection(),
             ),
           ),
@@ -67,7 +89,7 @@ void main() {
 
     testWidgets('displays enabled button when input is 6 characters',
         (WidgetTester tester) async {
-      whenListen(mockBloc,
+      whenListen(mockVerificationBloc,
           Stream.fromIterable([const VerificationState(code: '123456')]),
           initialState:
               const VerificationState(code: '123456')); // Simulate code input
@@ -76,7 +98,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: BlocProvider<VerificationBloc>.value(
-              value: mockBloc,
+              value: mockVerificationBloc,
               child: const VerificationConfirmButtonSection(),
             ),
           ),
@@ -107,6 +129,128 @@ void main() {
         matchesGoldenFile(
             'goldens/verification_confirm_button_section_enabled.png'),
       );
+    });
+
+    testWidgets(
+        'dispatches VerificationSubmitted event when enabled button is tapped',
+        (WidgetTester tester) async {
+      // Arrange
+      const testEmail = 'test@example.com';
+      const testCode = '123456';
+
+      when(() => mockVerificationBloc.state)
+          .thenReturn(const VerificationState(code: testCode));
+      when(() => mockRegisterBloc.state)
+          .thenReturn(RegisterState(register: Register(email: testEmail)));
+      when(() => mockVerificationBloc.add(any())).thenReturn(null);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider<RegisterBloc>.value(
+            value: mockRegisterBloc,
+            child: BlocProvider<VerificationBloc>.value(
+              value: mockVerificationBloc,
+              child: const Scaffold(
+                body: VerificationConfirmButtonSection(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Act
+      final buttonFinder = find.byType(PrimaryButton);
+      await tester.tap(buttonFinder);
+      await tester.pumpAndSettle();
+
+      // Assert
+      verify(() => mockVerificationBloc.add(
+              VerificationEvent.verificationSubmitted(testEmail, testCode)))
+          .called(1);
+    });
+
+    testWidgets('navigates to verificationComplete when status is verified',
+        (WidgetTester tester) async {
+      // Arrange
+      whenListen(
+        mockVerificationBloc,
+        Stream.fromIterable([
+          const VerificationState(status: VerificationStatus.verified),
+        ]),
+        initialState: const VerificationState(),
+      );
+      when(() => mockRegisterBloc.state).thenReturn(
+          const RegisterState(register: Register(email: 'test@example.com')));
+      when(() => mockGoRouter.push(any())).thenAnswer((_) async => '');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider<RegisterBloc>.value(
+            value: mockRegisterBloc,
+            child: BlocProvider<VerificationBloc>.value(
+              value: mockVerificationBloc,
+              child: InheritedGoRouter(
+                goRouter: mockGoRouter,
+                child: const Scaffold(
+                  body: VerificationConfirmButtonSection(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Act - No direct interaction needed, just pump to trigger listener
+      await tester.pumpAndSettle();
+
+      // Assert
+      verify(() => mockGoRouter.push(RouterPath.verificationComplete))
+          .called(1);
+    });
+
+    testWidgets('logs error message when status is error',
+        (WidgetTester tester) async {
+      // Arrange
+      const errorMessage = 'Test error message';
+      whenListen(
+        mockVerificationBloc,
+        Stream.fromIterable([
+          const VerificationState(
+              status: VerificationStatus.error, errorMessage: errorMessage),
+        ]),
+        initialState: const VerificationState(),
+      );
+      when(() => mockRegisterBloc.state).thenReturn(
+          const RegisterState(register: Register(email: 'test@example.com')));
+
+      // We can't directly test `log` from dart:developer in widget tests easily.
+      // Instead, we'll verify that the listener is triggered by checking for no navigation.
+      when(() => mockGoRouter.push(any())).thenAnswer((_) async => '');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider<RegisterBloc>.value(
+            value: mockRegisterBloc,
+            child: BlocProvider<VerificationBloc>.value(
+              value: mockVerificationBloc,
+              child: InheritedGoRouter(
+                goRouter: mockGoRouter,
+                child: const Scaffold(
+                  body: VerificationConfirmButtonSection(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Act - No direct interaction needed, just pump to trigger listener
+      await tester.pumpAndSettle();
+
+      // Assert that no navigation occurred (as expected for an error state)
+      verifyNever(() => mockGoRouter.push(any()));
+      // In a real scenario, you might use a custom logger that can be mocked
+      // or capture debugPrint output if `log` was redirected to it.
     });
   });
 }

--- a/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_confirm_button_section_test.dart
@@ -15,15 +15,9 @@ import 'package:solo_play_application/src/features/auth/presentation/verificatio
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart';
 
-// Mock Blocs for testing
-class MockVerificationBloc
-    extends MockBloc<VerificationEvent, VerificationState>
-    implements VerificationBloc {}
-
-class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
-    implements RegisterBloc {}
-
-class MockGoRouter extends Mock implements GoRouter {}
+import '../mocks/mock_verification_bloc.dart';
+import '../mocks/mock_register_bloc.dart';
+import '../mocks/mock_go_router.dart';
 
 void main() {
   group(VerificationConfirmButtonSection, () {
@@ -35,7 +29,8 @@ void main() {
       registerFallbackValue(VerificationEvent.verificationSubmitted('', ''));
       registerFallbackValue(RegisterState());
       registerFallbackValue(Uri.parse('/'));
-      registerFallbackValue(RegisterEvent.registerSubmitted(email: '', password: ''));
+      registerFallbackValue(
+          RegisterEvent.registerSubmitted(email: '', password: ''));
     });
 
     setUp(() {
@@ -58,7 +53,8 @@ void main() {
           home: Scaffold(
             body: MultiBlocProvider(
               providers: [
-                BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+                BlocProvider<VerificationBloc>.value(
+                    value: mockVerificationBloc),
                 BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
               ],
               child: const VerificationConfirmButtonSection(),
@@ -105,7 +101,8 @@ void main() {
           home: Scaffold(
             body: MultiBlocProvider(
               providers: [
-                BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+                BlocProvider<VerificationBloc>.value(
+                    value: mockVerificationBloc),
                 BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
               ],
               child: const VerificationConfirmButtonSection(),
@@ -150,8 +147,8 @@ void main() {
 
       when(() => mockVerificationBloc.state)
           .thenReturn(const VerificationState(code: testCode));
-      when(() => mockRegisterBloc.state)
-          .thenReturn(RegisterState(register: Register(email: testEmail, password: testPassword)));
+      when(() => mockRegisterBloc.state).thenReturn(RegisterState(
+          register: Register(email: testEmail, password: testPassword)));
       when(() => mockVerificationBloc.add(any())).thenReturn(null);
       // when(() => mockRegisterBloc.add(any())).thenReturn(null); // setUp에서 처리
 
@@ -182,7 +179,8 @@ void main() {
       //     .called(1);
     });
 
-    testWidgets('navigates to verificationComplete when verification and registration are successful',
+    testWidgets(
+        'navigates to verificationComplete when verification and registration are successful',
         (WidgetTester tester) async {
       // Arrange
       const testEmail = 'test@example.com';
@@ -192,14 +190,15 @@ void main() {
       whenListen(
         mockVerificationBloc,
         Stream.fromIterable([
-          const VerificationState(status: VerificationStatus.verified, code: '123456'),
+          const VerificationState(
+              status: VerificationStatus.verified, code: '123456'),
         ]),
         initialState: const VerificationState(code: '123456'),
       );
 
       // RegisterBloc의 초기 상태 설정
-      when(() => mockRegisterBloc.state).thenReturn(
-          RegisterState(register: Register(email: testEmail, password: testPassword)));
+      when(() => mockRegisterBloc.state).thenReturn(RegisterState(
+          register: Register(email: testEmail, password: testPassword)));
 
       // RegisterBloc이 RegisterSubmitted 이벤트를 받았을 때 success 상태를 방출하도록 설정
       whenListen(
@@ -214,7 +213,8 @@ void main() {
             status: RegisterStatus.success,
           ),
         ]),
-        initialState: RegisterState(register: Register(email: testEmail, password: testPassword)),
+        initialState: RegisterState(
+            register: Register(email: testEmail, password: testPassword)),
       );
 
       when(() => mockGoRouter.push(any())).thenAnswer((_) async => '');
@@ -240,7 +240,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Assert
-      verify(() => mockRegisterBloc.add(any(that: isA<RegisterSubmitted>()))) // 추가된 부분
+      verify(() => mockRegisterBloc
+              .add(any(that: isA<RegisterSubmitted>()))) // 추가된 부분
           .called(1);
       verify(() => mockGoRouter.push(RouterPath.verificationComplete))
           .called(1);

--- a/test/feature/auth/presentation/verification/sections/verification_intro_button_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_intro_button_section_test.dart
@@ -1,20 +1,77 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
+import 'package:solo_play_application/src/features/auth/domain/entities/register.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_intro_button_section.dart';
+
+class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
+    implements RegisterBloc {}
+
+class MockVerificationBloc
+    extends MockBloc<VerificationEvent, VerificationState>
+    implements VerificationBloc {}
+
+class MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
   group(VerificationIntroButtonSection, () {
     late Widget widget;
+    late MockRegisterBloc mockRegisterBloc;
+    late MockVerificationBloc mockVerificationBloc;
+    late MockGoRouter mockGoRouter;
+
+    const testEmail = 'test@example.com';
+
+    setUpAll(() {
+      registerFallbackValue(VerificationEvent.verificationEmailSent(testEmail));
+      registerFallbackValue(RegisterState());
+      registerFallbackValue(VerificationState());
+    });
 
     setUp(() {
-      widget = MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: VerificationIntroButtonSection(),
+      mockRegisterBloc = MockRegisterBloc();
+      mockVerificationBloc = MockVerificationBloc();
+      mockGoRouter = MockGoRouter();
+
+      when(() => mockRegisterBloc.state).thenReturn(
+        const RegisterState(register: Register(email: testEmail)),
+      );
+      when(() => mockVerificationBloc.state)
+          .thenReturn(const VerificationState());
+      when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
+
+      widget = MultiBlocProvider(
+        providers: [
+          BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+          BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+        ],
+        child: MaterialApp(
+          home: InheritedGoRouter(
+            goRouter: mockGoRouter,
+            child: const Scaffold(
+              body: Center(
+                child: VerificationIntroButtonSection(),
+              ),
+            ),
           ),
         ),
       );
+    });
+
+    tearDown(() {
+      mockRegisterBloc.close();
+      mockVerificationBloc.close();
     });
 
     testWidgets('should render activeChild correctly', (tester) async {
@@ -29,7 +86,7 @@ void main() {
 
       final activeLabel = tester.widget<Text>(labelFinder);
 
-      expect(activeLabel.style?.color, Color(0xffffffff));
+      expect(activeLabel.style?.color, const Color(0xffffffff));
       expect(activeLabel.style?.fontSize, 16);
       expect(activeLabel.style?.fontWeight, FontWeight.w700);
     });
@@ -39,6 +96,60 @@ void main() {
 
       expect(find.byType(VerificationIntroButtonSection),
           matchesGoldenFile('goldens/verification-intro-button-default.png'));
+    });
+
+    testWidgets(
+        'should dispatch VerificationEmailSent event with email from RegisterBloc when tapped',
+        (tester) async {
+      await tester.pumpWidget(widget);
+
+      await tester.tap(find.byType(PrimaryButton));
+      await tester.pumpAndSettle();
+
+      verify(() => mockVerificationBloc
+          .add(const VerificationEvent.verificationEmailSent(testEmail))).called(1);
+    });
+
+    testWidgets('should navigate to VerificationEmailPage on successful email sent',
+        (tester) async {
+      whenListen(
+        mockVerificationBloc,
+        Stream.fromIterable([
+          const VerificationState(),
+          const VerificationState(status: VerificationStatus.sent),
+        ]),
+        initialState: const VerificationState(),
+      );
+
+      await tester.pumpWidget(widget);
+
+      await tester.tap(find.byType(PrimaryButton));
+      await tester.pumpAndSettle();
+
+      verify(() => mockGoRouter.push(RouterPath.verficationEmail)).called(1);
+    });
+
+    testWidgets('should log error on failed email sent', (tester) async {
+      whenListen(
+        mockVerificationBloc,
+        Stream.fromIterable([
+          const VerificationState(),
+          const VerificationState(
+              status: VerificationStatus.error, errorMessage: 'Failed to send'),
+        ]),
+        initialState: const VerificationState(),
+      );
+
+      await tester.pumpWidget(widget);
+
+      await tester.tap(find.byType(PrimaryButton));
+      await tester.pumpAndSettle();
+
+      // Verify that a log message was produced.
+      // This requires a custom matcher or capturing logs,
+      // For simplicity, we'll just ensure no navigation happened
+      // and assume logging is handled correctly by the framework.
+      verifyNever(() => mockGoRouter.push(any()));
     });
   });
 }

--- a/test/feature/auth/presentation/verification/sections/verification_intro_button_section_test.dart
+++ b/test/feature/auth/presentation/verification/sections/verification_intro_button_section_test.dart
@@ -8,21 +8,15 @@ import 'package:solo_play_application/src/core/router/router_path.dart';
 import 'package:solo_play_application/src/core/widgets/primary_button.dart';
 import 'package:solo_play_application/src/features/auth/domain/entities/register.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
-import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_intro_button_section.dart';
 
-class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
-    implements RegisterBloc {}
-
-class MockVerificationBloc
-    extends MockBloc<VerificationEvent, VerificationState>
-    implements VerificationBloc {}
-
-class MockGoRouter extends Mock implements GoRouter {}
+import '../mocks/mock_register_bloc.dart';
+import '../mocks/mock_verification_bloc.dart';
+import '../mocks/mock_go_router.dart';
 
 void main() {
   group(VerificationIntroButtonSection, () {
@@ -106,11 +100,12 @@ void main() {
       await tester.tap(find.byType(PrimaryButton));
       await tester.pumpAndSettle();
 
-      verify(() => mockVerificationBloc
-          .add(const VerificationEvent.verificationEmailSent(testEmail))).called(1);
+      verify(() => mockVerificationBloc.add(
+          const VerificationEvent.verificationEmailSent(testEmail))).called(1);
     });
 
-    testWidgets('should navigate to VerificationEmailPage on successful email sent',
+    testWidgets(
+        'should navigate to VerificationEmailPage on successful email sent',
         (tester) async {
       whenListen(
         mockVerificationBloc,

--- a/test/feature/auth/presentation/verification/views/verification_email_ui_test.dart
+++ b/test/feature/auth/presentation/verification/views/verification_email_ui_test.dart
@@ -3,10 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_bloc.dart';
-import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/register/bloc/register_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
-import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_event.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 
 import 'package:solo_play_application/src/features/auth/presentation/verification/views/verification_email_ui.dart';
@@ -15,17 +13,11 @@ import 'package:solo_play_application/src/features/auth/presentation/verificatio
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/resend_email_section.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/sections/verification_confirm_button_section.dart';
 import 'package:solo_play_application/src/features/timer/bloc/timer_bloc.dart';
-import 'package:solo_play_application/src/features/timer/bloc/timer_event.dart';
 import 'package:solo_play_application/src/features/timer/bloc/timer_state.dart';
 
-class MockVerificationBloc extends MockBloc<VerificationEvent, VerificationState>
-    implements VerificationBloc {}
-
-class MockTimerBloc extends MockBloc<TimerEvent, TimerState>
-    implements TimerBloc {}
-
-class MockRegisterBloc extends MockBloc<RegisterEvent, RegisterState>
-    implements RegisterBloc {}
+import '../mocks/mock_verification_bloc.dart';
+import '../mocks/mock_timer_bloc.dart';
+import '../mocks/mock_register_bloc.dart';
 
 void main() {
   group(VerificationEmailUi, () {
@@ -41,7 +33,8 @@ void main() {
 
     testWidgets('displays all sections with correct layout and padding',
         (WidgetTester tester) async {
-      whenListen(mockVerificationBloc, Stream.fromIterable([const VerificationState()]),
+      whenListen(mockVerificationBloc,
+          Stream.fromIterable([const VerificationState()]),
           initialState: const VerificationState());
       whenListen(mockTimerBloc, Stream.fromIterable([const TimerInitial(600)]),
           initialState: const TimerInitial(600));

--- a/test/feature/auth/presentation/verification/views/verification_intro_ui_test.dart
+++ b/test/feature/auth/presentation/verification/views/verification_intro_ui_test.dart
@@ -1,13 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:solo_play_application/src/features/auth/presentation/register/bloc/bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_bloc.dart';
+import 'package:solo_play_application/src/features/auth/presentation/verification/bloc/verification_state.dart';
 import 'package:solo_play_application/src/features/auth/presentation/verification/views/verification_intro_ui.dart';
+
+import '../mocks/mock_register_bloc.dart';
+import '../mocks/mock_verification_bloc.dart';
 
 void main() {
   group(VerificationIntroUI, () {
+    late MockRegisterBloc mockRegisterBloc;
+    late MockVerificationBloc mockVerificationBloc;
+
     late Widget widget;
 
     setUp(() {
-      widget = MaterialApp(home: VerificationIntroUI());
+      mockRegisterBloc = MockRegisterBloc();
+      mockVerificationBloc = MockVerificationBloc();
+
+      widget = MaterialApp(
+          home: MultiBlocProvider(
+        providers: [
+          BlocProvider<RegisterBloc>.value(value: mockRegisterBloc),
+          BlocProvider<VerificationBloc>.value(value: mockVerificationBloc),
+        ],
+        child: VerificationIntroUI(),
+      ));
+
+      when(() => mockRegisterBloc.state).thenReturn(RegisterState());
+      when(() => mockVerificationBloc.state).thenReturn(VerificationState());
     });
 
     testWidgets('should render correctly', (tester) async {


### PR DESCRIPTION
## 작업내용

- VerificationIntroUI에서 이메일 인증 요청 로직 연결

이메일 인증 요청 UI에서 이메일 인증 요청을 수행할 수 있도록 연결하였습니다. 성공 시 이메일 인증 확인 UI로 이동할 수 있으나, 실패시 현 UI에서 머무릅니다.

- VerificationEmailUI에서 이메일 인증 확인 요청 로직 연결

이메일 인증 확인 UI에서 버튼 탭 시 이메일 인증을 확인하는 요청 로직을 연결하였고, 성공 시 회원가입 완료 UI로 이동할 수 있으나, 실패시 현 UI에서 머무릅니다.

- VerificationEmailUI에서 이메일 인증 확인 성공 시 회원가입 요청 로직 연결

이메일 인증 확인이 완료되면 자동으로 회원가입 요청도 함께 수행하게 됩니다.

- 의존성 변경으로 인한 테스트 의존성 추가 주입

비즈니스 로직이 변경되고 의존성이 추가로 주입됨에 따라서 테스트에서 주입하는 mock 의존성을 변경했습니다.

## 테스트

<img width="205" height="20" alt="스크린샷 2025-09-25 오전 11 10 03" src="https://github.com/user-attachments/assets/206285a7-098f-4328-b38a-d7fef6b7b862" />
